### PR TITLE
recherche des chemins de fichiers

### DIFF
--- a/AudioFileSet.cpp
+++ b/AudioFileSet.cpp
@@ -100,7 +100,7 @@ int AudioFileSet::loadFileSet(string localPath)
 
 
             // construct path
-            string myPath = localPath + theFileName;
+            string myPath = localPath + '/' + theFileName;
 
 
             // temp struct that will hold the details of the file being read (sample rate, num channels. etc.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,11 @@ include(FindPkgConfig)
 
 target_compile_definitions(Frontieres
   PRIVATE "__LINUX_ALSASEQ__=" "__UNIX_JACK__="
-  PRIVATE "INSTALL_PREFIX=\"${CMAKE_INSTALL_PREFIX}\""
-  PRIVATE "DATA_ROOT_DIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}\"")
+  PRIVATE "INSTALL_PREFIX=\"${CMAKE_INSTALL_PREFIX}\"")
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_compile_definitions(Frontieres
+    PRIVATE "DATA_ROOT_DIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}\"")
+endif()
 
 set(OpenGL_GL_PREFERENCE "GLVND")
 find_package(OpenGL REQUIRED)

--- a/MyGLApplication.cpp
+++ b/MyGLApplication.cpp
@@ -23,10 +23,15 @@
 #include "MyGLWindow.h"
 #include <QTranslator>
 #include <QLibraryInfo>
+#include <QStandardPaths>
+#include <QDir>
 #include <QTimer>
 #include <QDebug>
 
 struct MyGLApplication::Impl {
+    // location of user files
+    QString userDataPath;
+
     // translator of the internal parts of Qt
     QTranslator qtTranslator;
     // translator of the application itself
@@ -45,6 +50,9 @@ MyGLApplication::MyGLApplication(int &argc, char *argv[])
     : QApplication(argc, argv),
       P(new Impl)
 {
+    // find the user directories
+    P->userDataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+
     // init internationalization
     installTranslator(&P->qtTranslator);
     installTranslator(&P->appTranslator);
@@ -79,6 +87,11 @@ void MyGLApplication::startIdleCallback(double fps)
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, [this]{ P->onIdle(); });
     timer->start(1e3 / fps);
+}
+
+const QString &MyGLApplication::getUserDataPath()
+{
+    return P->userDataPath;
 }
 
 void MyGLApplication::Impl::onIdle()

--- a/MyGLApplication.h
+++ b/MyGLApplication.h
@@ -30,6 +30,8 @@ public:
     MyGLWindow *GLwindow();
     void startIdleCallback(double fps);
 
+    const QString &getUserDataPath();
+
 private:
     struct Impl;
     std::unique_ptr<Impl> P;

--- a/translations/Frontieres_fr_FR.ts
+++ b/translations/Frontieres_fr_FR.ts
@@ -4,132 +4,151 @@
 <context>
     <name></name>
     <message>
-        <location filename="../Frontieres.cpp" line="402"/>
+        <location filename="../Frontieres.cpp" line="405"/>
         <source>CLICK TO START</source>
         <translation>CLIC POUR DÉMARRER</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="410"/>
+        <location filename="../Frontieres.cpp" line="413"/>
         <source>ESCAPE TO QUIT</source>
         <translation>ÉCHAP POUR QUITTER</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="419"/>
         <source>PUT THE SAMPLES IN ~/.Frontieres/loops</source>
-        <translation>PLACEZ LES ÉCHANTILLONS DANS ~/.Frontieres/loops</translation>
+        <translation type="vanished">PLACEZ LES ÉCHANTILLONS DANS ~/.Frontieres/loops</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="442"/>
+        <location filename="../Frontieres.cpp" line="422"/>
+        <source>PUT THE SAMPLES IN %0</source>
+        <translation>PLACEZ LES ÉCHANTILLONS DANS %0</translation>
+    </message>
+    <message>
+        <location filename="../Frontieres.cpp" line="446"/>
         <source>Voices: </source>
         <translation>Voix : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="449"/>
+        <location filename="../Frontieres.cpp" line="453"/>
         <source>Duration: </source>
         <translation>Durée : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="464"/>
+        <location filename="../Frontieres.cpp" line="468"/>
         <source>Window: HANNING</source>
         <translation>Fenêtre : HANNING</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="467"/>
+        <location filename="../Frontieres.cpp" line="471"/>
         <source>Window: TRIANGLE</source>
         <translation>Fenêtre : TRIANGLE</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="470"/>
+        <location filename="../Frontieres.cpp" line="474"/>
         <source>Window: REXPDEC</source>
         <translation>Fenêtre : REXPDEC</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="473"/>
+        <location filename="../Frontieres.cpp" line="477"/>
         <source>Window: EXPDEC</source>
         <translation>Fenêtre : EXPDEC</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="476"/>
+        <location filename="../Frontieres.cpp" line="480"/>
         <source>Window: SINC</source>
         <translation>Fenêtre : SINC</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="479"/>
+        <location filename="../Frontieres.cpp" line="483"/>
         <source>Window: RANDOM_WIN</source>
         <translation>Fenêtre : RANDOM_WIN</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="490"/>
+        <location filename="../Frontieres.cpp" line="494"/>
         <source>X: </source>
         <translation>X : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="497"/>
+        <location filename="../Frontieres.cpp" line="501"/>
         <source>Y: </source>
         <translation>Y : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="504"/>
+        <location filename="../Frontieres.cpp" line="508"/>
         <source>X,Y: </source>
         <translation>X, Y : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="516"/>
+        <location filename="../Frontieres.cpp" line="520"/>
         <source>Direction: FORWARD</source>
         <translation>Direction : EN AVANT</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="519"/>
+        <location filename="../Frontieres.cpp" line="523"/>
         <source>Direction: BACKWARD</source>
         <translation>Direction : EN ARRIÈRE</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="522"/>
+        <location filename="../Frontieres.cpp" line="526"/>
         <source>Direction: RANDOM</source>
         <translation>Direction : HASARD</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="535"/>
+        <location filename="../Frontieres.cpp" line="539"/>
         <source>Spatial Mode: UNITY</source>
         <translation>Balance panoramique : UNITÉ</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="538"/>
+        <location filename="../Frontieres.cpp" line="542"/>
         <source>Spatial Mode: STEREO</source>
         <translation>Balance panoramique : STÉRÉO</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="541"/>
+        <location filename="../Frontieres.cpp" line="545"/>
         <source>Spatial Mode: AROUND</source>
         <translation>Balance panoramique : AUTOUR</translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="551"/>
+        <location filename="../Frontieres.cpp" line="555"/>
         <source>Volume (dB): </source>
         <translation>Volume (dB) : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="563"/>
+        <location filename="../Frontieres.cpp" line="567"/>
         <source>Overlap: </source>
         <translation>Chevauchement : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="576"/>
+        <location filename="../Frontieres.cpp" line="580"/>
         <source>Pitch: </source>
         <translation>Tonalité : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="590"/>
+        <location filename="../Frontieres.cpp" line="594"/>
         <source>Pitch LFO Freq: </source>
         <translation>Fréquence LFO de la tonalité : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="603"/>
+        <location filename="../Frontieres.cpp" line="607"/>
         <source>Pitch LFO Amount: </source>
         <translation>Quantité LFO de la tonalité : </translation>
     </message>
     <message>
-        <location filename="../Frontieres.cpp" line="871"/>
+        <location filename="../Frontieres.cpp" line="861"/>
+        <source>The directory of user loops is not empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Frontieres.cpp" line="865"/>
+        <source>The directory of user loops is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Frontieres.cpp" line="877"/>
+        <source>Could not find any sounds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Frontieres.cpp" line="881"/>
         <source>Sounds loaded successfully...</source>
         <translation>Succès du chargement des sons...</translation>
     </message>


### PR DESCRIPTION
#16 

Modification du chemin de recherche des fichiers audio

- en premier lieu on regardera si le chemin utilisateur est rempli, auquel cas on l'utilise.
Ce chemin est sélectionné d'une manière portable à l'aide des `QStandardPaths`. Sous Linux, ce sera le chemin `.local/share/Frontieres/loops`
- à défaut, sur un OS non-Windows, on recherchera dans `PREFIX`/share
- en dernier lieu, on recherche en relatif par rapport à l'exécutable. cela permet de couvrir le cas Windows, et en plus le cas développeur lorsque les fichiers ne seraient pas installés à leur destination.

Autre élément : je permets au programme de se lancer même s'il n'y a aucun son.
Cela deviendra utile quand on pourra ajouter des sons dynamiquement.