### PR TITLE
ajout fonctions sauvegarde et recharge de parametres de clouds

### DIFF
--- a/sources/Frontieres.cpp
+++ b/sources/Frontieres.cpp
@@ -603,7 +603,7 @@ void printParam()
             //            myValue = "Duration (ms): " + theCloud->getDurationMs();
             break;
         case NUM:
-            myValue = _S("", "Cloud Num: ") + std::to_string(theCloud.getId());
+            myValue = _S("", "Cloud Num: ") + std::to_string(currentScene->getNumCloud(selectedCloud)+1);
             draw_string((GLfloat)mouseX, (GLfloat)(screenHeight - mouseY), 0.0,
                         myValue.c_str(), 100.0f);
             break;

--- a/sources/Frontieres.cpp
+++ b/sources/Frontieres.cpp
@@ -151,7 +151,7 @@ long lastDragY = veryHighNumber;
 
 // text renderer
 QtFont3D *text_renderer = NULL;
-
+CloudParams g_defaultCloudParams;
 //--------------------------------------------------------------------------------
 // FUNCTION PROTOTYPES
 //--------------------------------------------------------------------------------

--- a/sources/interface/MyGLApplication.cpp
+++ b/sources/interface/MyGLApplication.cpp
@@ -23,7 +23,6 @@
 #include "MyGLWindow.h"
 #include "Frontieres.h"
 #include "I18n.h"
-#include "model/Scene.h"
 #include "model/AudioFileSet.h"
 #include <QTranslator>
 #include <QLibraryInfo>
@@ -130,14 +129,14 @@ bool MyGLApplication::saveSceneFile()
     return ::currentScene->save(sceneFile);
 }
 
-bool MyGLApplication::saveCloudFile(int numCloud)
+bool MyGLApplication::saveCloudFile(SceneCloud *selectedCloudSave)
 {
     std::string nameCloudFile = Scene::askNameCloud(FileDirection::Save);
     if (nameCloudFile.empty())
         return false;
 
     QFile cloudFile(QString::fromStdString(nameCloudFile));
-    return ::currentScene->saveCloud(cloudFile, numCloud);
+    return ::currentScene->saveCloud(cloudFile, selectedCloudSave);
 }
 
 void MyGLApplication::addSound()

--- a/sources/interface/MyGLApplication.cpp
+++ b/sources/interface/MyGLApplication.cpp
@@ -109,6 +109,17 @@ bool MyGLApplication::loadSceneFile()
     return true;
 }
 
+bool MyGLApplication::loadCloudDefaultFile()
+{
+    std::string nameCloudFile = Scene::askNameCloud(FileDirection::Load);
+    if (nameCloudFile.empty())
+        return false;
+    // load the clouds default params file
+
+    QFile cloudFile(QString::fromStdString(nameCloudFile));
+    return currentScene->loadCloudDefault(cloudFile);
+}
+
 bool MyGLApplication::saveSceneFile()
 {
     std::string nameSceneFile = Scene::askNameScene(FileDirection::Save);
@@ -117,6 +128,16 @@ bool MyGLApplication::saveSceneFile()
 
     QFile sceneFile(QString::fromStdString(nameSceneFile));
     return ::currentScene->save(sceneFile);
+}
+
+bool MyGLApplication::saveCloudFile(int numCloud)
+{
+    std::string nameCloudFile = Scene::askNameCloud(FileDirection::Save);
+    if (nameCloudFile.empty())
+        return false;
+
+    QFile cloudFile(QString::fromStdString(nameCloudFile));
+    return ::currentScene->saveCloud(cloudFile, numCloud);
 }
 
 void MyGLApplication::addSound()

--- a/sources/interface/MyGLApplication.h
+++ b/sources/interface/MyGLApplication.h
@@ -32,6 +32,8 @@ public:
 
     bool loadSceneFile();
     bool saveSceneFile();
+    bool saveCloudFile(int numCloud);
+    bool loadCloudDefaultFile();
     void addSound();
 
 private:

--- a/sources/interface/MyGLApplication.h
+++ b/sources/interface/MyGLApplication.h
@@ -21,6 +21,8 @@
 
 #include <QApplication>
 #include <memory>
+#include "model/Scene.h"
+
 class MyGLWindow;
 
 class MyGLApplication : public QApplication {
@@ -32,7 +34,7 @@ public:
 
     bool loadSceneFile();
     bool saveSceneFile();
-    bool saveCloudFile(int numCloud);
+    bool saveCloudFile(SceneCloud *selectedCloudSave);
     bool loadCloudDefaultFile();
     void addSound();
 

--- a/sources/interface/MyGLWindow.cpp
+++ b/sources/interface/MyGLWindow.cpp
@@ -54,12 +54,15 @@ void MyGLWindow::initialize()
 
     connect(P->ui.action_Quit, &QAction::triggered,
             qApp, &QApplication::quit);
-    connect(P->ui.action_Load, &QAction::triggered,
+    connect(P->ui.action_Load_scene, &QAction::triggered,
             this, []() { theApplication->loadSceneFile(); });
-    connect(P->ui.action_Save, &QAction::triggered,
+    connect(P->ui.action_Save_scene, &QAction::triggered,
             this, []() { theApplication->saveSceneFile(); });
     connect(P->ui.action_Add_sound, &QAction::triggered,
             this, []() { theApplication->addSound(); });
+    connect(P->ui.action_Load_clouds_defaults, &QAction::triggered,
+            this, []() { theApplication->loadCloudDefaultFile(); });
+
 
     // initial window settings
     QSurfaceFormat format = QSurfaceFormat::defaultFormat();
@@ -878,6 +881,13 @@ void MyGLScreen::keyPressEvent(QKeyEvent *event)
             paramString = "";
             if (currentParam != NUM)
                 currentParam = NUM;
+        }
+        break;
+    }
+    case Qt::Key_C: {
+        // record cloud parameters
+        if (selectedCloud) {
+            theApplication->saveCloudFile(selectedCloud->cloud->getId()-1);
         }
         break;
     }

--- a/sources/interface/MyGLWindow.cpp
+++ b/sources/interface/MyGLWindow.cpp
@@ -887,7 +887,7 @@ void MyGLScreen::keyPressEvent(QKeyEvent *event)
     case Qt::Key_C: {
         // record cloud parameters
         if (selectedCloud) {
-            theApplication->saveCloudFile(selectedCloud->cloud->getId()-1);
+            theApplication->saveCloudFile(selectedCloud);
         }
         break;
     }

--- a/sources/interface/MyGLWindow.ui
+++ b/sources/interface/MyGLWindow.ui
@@ -45,8 +45,10 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
-    <addaction name="action_Load"/>
-    <addaction name="action_Save"/>
+    <addaction name="action_Load_scene"/>
+    <addaction name="action_Save_scene"/>
+    <addaction name="separator"/>
+    <addaction name="action_Load_clouds_defaults"/>
     <addaction name="separator"/>
     <addaction name="action_Quit"/>
    </widget>
@@ -59,17 +61,17 @@
    <addaction name="menu_File"/>
    <addaction name="menu_Edit"/>
   </widget>
-  <action name="action_Load">
+  <action name="action_Load_scene">
    <property name="text">
-    <string>&amp;Load...</string>
+    <string>&amp;Load scene</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
    </property>
   </action>
-  <action name="action_Save">
+  <action name="action_Save_scene">
    <property name="text">
-    <string>&amp;Save...</string>
+    <string>&amp;Save scene</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
@@ -83,6 +85,11 @@
   <action name="action_Add_sound">
    <property name="text">
     <string>&amp;Add sounds...</string>
+   </property>
+  </action>
+  <action name="action_Load_clouds_defaults">
+   <property name="text">
+    <string>Load &amp;clouds defaults</string>
    </property>
   </action>
  </widget>

--- a/sources/model/GrainCluster.cpp
+++ b/sources/model/GrainCluster.cpp
@@ -57,7 +57,8 @@ GrainCluster::GrainCluster(VecSceneSound *soundSet, float theNumVoices)
     awaitingPlay = false;
 
     // number of voices
-    numVoices = theNumVoices;
+    //numVoices = theNumVoices;
+    numVoices = g_defaultCloudParams.numVoices;
     // initialize random number generator (for random motion)
     srand(time(NULL));
 
@@ -75,18 +76,22 @@ GrainCluster::GrainCluster(VecSceneSound *soundSet, float theNumVoices)
     local_time = 0;
 
     // default duration (ms)
-    duration = 500.0;
+    //duration = 500.0;
+    duration = g_defaultCloudParams.duration;
 
     // default pitch
-    pitch = 1.0f;
+    //pitch = 1.0f;
+    pitch = g_defaultCloudParams.pitch;
 
     // default window type
-    windowType = HANNING;
+    //windowType = HANNING;
+    windowType = g_defaultCloudParams.windowType;
 
     // initialize pitch LFO
-    pitchLFOFreq = 0.01f;
-    pitchLFOAmount = 0.0f;
-
+    //pitchLFOFreq = 0.01f;
+    pitchLFOFreq = g_defaultCloudParams.pitchLFOFreq;
+    //pitchLFOAmount = 0.0f;
+    pitchLFOAmount = g_defaultCloudParams.pitchLFOAmount;
     // initialize channel multiplier array
     channelMults = new double[MY_CHANNELS];
     for (int i = 0; i < MY_CHANNELS; i++) {
@@ -98,10 +103,12 @@ GrainCluster::GrainCluster(VecSceneSound *soundSet, float theNumVoices)
     side = 1;
 
 
-    spatialMode = UNITY;
-    channelLocation = -1;
-
-    myDirMode = RANDOM_DIR;
+    //spatialMode = UNITY;
+    spatialMode = g_defaultCloudParams.spatialMode;
+    //channelLocation = -1;
+    channelLocation = g_defaultCloudParams.chanelLocation;
+    //myDirMode = RANDOM_DIR;
+    myDirMode = g_defaultCloudParams.dirMode;
 
     // populate grain cloud
     for (int i = 0; i < numVoices; i++) {
@@ -109,10 +116,12 @@ GrainCluster::GrainCluster(VecSceneSound *soundSet, float theNumVoices)
     }
 
     // set volume of cloud to unity
-    setVolumeDb(0.0);
+    //setVolumeDb(0.0);
+    setVolumeDb(g_defaultCloudParams.volumeDB);
 
     // set overlap (default to full overlap)
-    setOverlap(1.0f);
+    //setOverlap(1.0f);
+    setOverlap(g_defaultCloudParams.overlap);
 
     //    //direction
     //    setDirection(RANDOM_DIR);
@@ -126,10 +135,9 @@ GrainCluster::GrainCluster(VecSceneSound *soundSet, float theNumVoices)
     }
 
     // state - (user can remove cloud from "play" for editing)
-    isActive = true;
+    //isActive = true;
+    isActive = g_defaultCloudParams.activateState;
 }
-
-
 // register controller for communication with view
 void GrainCluster::registerVis(GrainClusterVis *vis)
 {

--- a/sources/model/GrainCluster.h
+++ b/sources/model/GrainCluster.h
@@ -30,6 +30,7 @@
 #ifndef GRAIN_CLUSTER_H
 #define GRAIN_CLUSTER_H
 
+#include "theglobals.h"
 #include <Stk.h>
 #include <map>
 #include <vector>
@@ -39,6 +40,10 @@
 #include <cstdlib>
 #include <time.h>
 #include <ctime>
+#include <QFile>
+#include <QDir>
+#include <QJsonObject>
+#include <QJsonArray>
 class GrainVoice;
 struct SceneSound;
 
@@ -63,8 +68,7 @@ class GrainClusterVis;
 
 // ids
 static unsigned int clusterId = 0;
-
-
+extern CloudParams g_defaultCloudParams;
 // class interface
 class GrainCluster {
 

--- a/sources/model/Scene.cpp
+++ b/sources/model/Scene.cpp
@@ -367,40 +367,36 @@ bool Scene::loadCloudDefault(QFile &cloudFile)
 
     QJsonObject docRoot = doc.object();
 
-    QJsonArray docGrains = docRoot["cloud"].toArray();
-    for (const QJsonValue &jsonElement : docGrains) {
-        QJsonObject objGrain = jsonElement.toObject();
+    QJsonObject objGrain = docRoot["cloud"].toObject();
+    g_defaultCloudParams.duration = objGrain["duration"].toDouble();
+    g_defaultCloudParams.overlap = objGrain["overlap"].toDouble();
+    g_defaultCloudParams.pitch = objGrain["pitch"].toDouble();
+    g_defaultCloudParams.pitchLFOFreq = objGrain["pitch-lfo-freq"].toDouble();
+    g_defaultCloudParams.pitchLFOAmount = objGrain["pitch-lfo-amount"].toDouble();
+    g_defaultCloudParams.dirMode = objGrain["direction"].toInt();
+    g_defaultCloudParams.windowType = objGrain["window-type"].toInt();
+    g_defaultCloudParams.spatialMode = objGrain["spatial-mode"].toInt();
+    g_defaultCloudParams.chanelLocation = objGrain["spatial-channel"].toInt();
+    g_defaultCloudParams.volumeDB = objGrain["volume"].toDouble();
+    g_defaultCloudParams.numVoices = objGrain["num-voices"].toInt();
+    g_defaultCloudParams.activateState = objGrain["active-state"].toBool();
+    g_defaultCloudParams.xRandExtent = objGrain["x-rand-extent"].toDouble();
+    g_defaultCloudParams.yRandExtent = objGrain["y-rand-extent"].toDouble();
 
-        g_defaultCloudParams.duration = objGrain["duration"].toDouble();
-        g_defaultCloudParams.overlap = objGrain["overlap"].toDouble();
-        g_defaultCloudParams.pitch = objGrain["pitch"].toDouble();
-        g_defaultCloudParams.pitchLFOFreq = objGrain["pitch-lfo-freq"].toDouble();
-        g_defaultCloudParams.pitchLFOAmount = objGrain["pitch-lfo-amount"].toDouble();
-        g_defaultCloudParams.dirMode = objGrain["direction"].toInt();
-        g_defaultCloudParams.windowType = objGrain["window-type"].toInt();
-        g_defaultCloudParams.spatialMode = objGrain["spatial-mode"].toInt();
-        g_defaultCloudParams.chanelLocation = objGrain["spatial-channel"].toInt();
-        g_defaultCloudParams.volumeDB = objGrain["volume"].toDouble();
-        g_defaultCloudParams.numVoices = objGrain["num-voices"].toInt();
-        g_defaultCloudParams.activateState = objGrain["active-state"].toBool();
-        g_defaultCloudParams.xRandExtent = objGrain["x-rand-extent"].toDouble();
-        g_defaultCloudParams.yRandExtent = objGrain["y-rand-extent"].toDouble();
-
-        cout << "duration = " << g_defaultCloudParams.duration << "\n";
-        cout << "overlap = " << g_defaultCloudParams.overlap << "\n";
-        cout << "pitch = " << g_defaultCloudParams.pitch << "\n";
-        cout << "pitchLFOFreq = " << g_defaultCloudParams.pitchLFOFreq << "\n";
-        cout << "pitchLFOAmount = " << g_defaultCloudParams.pitchLFOAmount << "\n";
-        cout << "direction = " << g_defaultCloudParams.dirMode << "\n";
-        cout << "window type = " << g_defaultCloudParams.windowType << "\n";
-        cout << "spatial mode = " << g_defaultCloudParams.spatialMode << "\n";
-        cout << "spatial channel = " << g_defaultCloudParams.chanelLocation << "\n";
-        cout << "volume = " << g_defaultCloudParams.volumeDB << "\n";
-        cout << "voices = " << g_defaultCloudParams.numVoices << "\n";
-        cout << "active = " << g_defaultCloudParams.activateState << "\n";
-        cout << "xRandExtent = " << g_defaultCloudParams.xRandExtent << "\n";
-        cout << "yRandExtent = " << g_defaultCloudParams.yRandExtent << "\n";
-    }
+    cout << "duration = " << g_defaultCloudParams.duration << "\n";
+    cout << "overlap = " << g_defaultCloudParams.overlap << "\n";
+    cout << "pitch = " << g_defaultCloudParams.pitch << "\n";
+    cout << "pitchLFOFreq = " << g_defaultCloudParams.pitchLFOFreq << "\n";
+    cout << "pitchLFOAmount = " << g_defaultCloudParams.pitchLFOAmount << "\n";
+    cout << "direction = " << g_defaultCloudParams.dirMode << "\n";
+    cout << "window type = " << g_defaultCloudParams.windowType << "\n";
+    cout << "spatial mode = " << g_defaultCloudParams.spatialMode << "\n";
+    cout << "spatial channel = " << g_defaultCloudParams.chanelLocation << "\n";
+    cout << "volume = " << g_defaultCloudParams.volumeDB << "\n";
+    cout << "voices = " << g_defaultCloudParams.numVoices << "\n";
+    cout << "active = " << g_defaultCloudParams.activateState << "\n";
+    cout << "xRandExtent = " << g_defaultCloudParams.xRandExtent << "\n";
+    cout << "yRandExtent = " << g_defaultCloudParams.yRandExtent << "\n";
 
     return true;
 
@@ -412,54 +408,51 @@ bool Scene::saveCloud(QFile &cloudFile, int numCloud)
     QDir cloudFileDir = QFileInfo(cloudFileName).dir();
 
     if (!cloudFile.open(QIODevice::WriteOnly | QIODevice::Text))
-            return false;
+        return false;
 
-        QJsonObject docRoot;
+    QJsonObject docRoot;
 
-        // audio path
-        cout << "record cloud " << cloudFile.fileName().toStdString() << "\n";
+    // audio path
+    cout << "record cloud " << cloudFile.fileName().toStdString() << "\n";
 
-        QJsonArray docPaths;
+    QJsonArray docPaths;
 
-        // graincloud
+    // graincloud
 
-        QJsonArray docGrains;
-        SceneCloud *cloud = m_clouds[numCloud].get();
-        GrainCluster *gc = cloud->cloud.get();
-        GrainClusterVis *gv = cloud->view.get();
+    SceneCloud *cloud = m_clouds[numCloud].get();
+    GrainCluster *gc = cloud->cloud.get();
+    GrainClusterVis *gv = cloud->view.get();
 
-        std::ostream &out = std::cout;
-        out << "Grain Cloud " << numCloud << ":";
-        gc->describe(out);
+    std::ostream &out = std::cout;
+    out << "Grain Cloud " << numCloud << ":";
+    gc->describe(out);
 
-        QJsonObject objGrain;
-        objGrain["duration"] = gc->getDurationMs();
-        objGrain["overlap"] = gc->getOverlap();
-        objGrain["pitch"] = gc->getPitch();
-        objGrain["pitch-lfo-freq"] = gc->getPitchLFOFreq();
-        objGrain["pitch-lfo-amount"] = gc->getPitchLFOAmount();
-        objGrain["direction"] = gc->getDirection();
-        objGrain["window-type"] = gc->getWindowType();
-        objGrain["spatial-mode"] = gc->getSpatialMode();
-        objGrain["spatial-channel"] = gc->getSpatialChannel();
-        objGrain["volume"] = gc->getVolumeDb();
-        objGrain["num-voices"] = (int)gc->getNumVoices();
-        objGrain["active-state"] = gc->getActiveState();
-        objGrain["x-rand-extent"] = gv->getXRandExtent();
-        objGrain["y-rand-extent"] = gv->getYRandExtent();
+    QJsonObject objGrain;
+    objGrain["duration"] = gc->getDurationMs();
+    objGrain["overlap"] = gc->getOverlap();
+    objGrain["pitch"] = gc->getPitch();
+    objGrain["pitch-lfo-freq"] = gc->getPitchLFOFreq();
+    objGrain["pitch-lfo-amount"] = gc->getPitchLFOAmount();
+    objGrain["direction"] = gc->getDirection();
+    objGrain["window-type"] = gc->getWindowType();
+    objGrain["spatial-mode"] = gc->getSpatialMode();
+    objGrain["spatial-channel"] = gc->getSpatialChannel();
+    objGrain["volume"] = gc->getVolumeDb();
+    objGrain["num-voices"] = (int)gc->getNumVoices();
+    objGrain["active-state"] = gc->getActiveState();
+    objGrain["x-rand-extent"] = gv->getXRandExtent();
+    objGrain["y-rand-extent"] = gv->getYRandExtent();
 
-        docGrains.append(objGrain);
+    docRoot["cloud"] = objGrain;
 
-        docRoot["cloud"] = docGrains;
+    QJsonDocument document;
+    document.setObject(docRoot);
+    cloudFile.write(document.toJson());
+    if (!cloudFile.flush())
+        return false;
 
-        QJsonDocument document;
-        document.setObject(docRoot);
-        cloudFile.write(document.toJson());
-        if (!cloudFile.flush())
-            return false;
-
-        return true;
-    }
+    return true;
+}
 
 bool Scene::loadSampleSet(bool interactive)
 {

--- a/sources/model/Scene.cpp
+++ b/sources/model/Scene.cpp
@@ -717,6 +717,18 @@ void Scene::deselect(int shapeType)
         break;
     }
 }
+// get num of a cloud in current scene
+int Scene::getNumCloud(SceneCloud *cloudForNum)
+{
+    for (int i = 0, n = m_clouds.size(); i < n; i++) {
+        GrainCluster *gcForNum = cloudForNum->cloud.get();
+        GrainCluster *gc = m_clouds[i]->cloud.get();
+        if (gcForNum->getId() == gc->getId())
+            return i;
+    }
+    return -1;
+}
+
 
 // destructor
 SceneSound::~SceneSound()

--- a/sources/model/Scene.cpp
+++ b/sources/model/Scene.cpp
@@ -402,7 +402,7 @@ bool Scene::loadCloudDefault(QFile &cloudFile)
 
 }
 
-bool Scene::saveCloud(QFile &cloudFile, int numCloud)
+bool Scene::saveCloud(QFile &cloudFile, SceneCloud *selectedCloudSave)
 {
     QString cloudFileName = cloudFile.fileName();
     QDir cloudFileDir = QFileInfo(cloudFileName).dir();
@@ -419,12 +419,11 @@ bool Scene::saveCloud(QFile &cloudFile, int numCloud)
 
     // graincloud
 
-    SceneCloud *cloud = m_clouds[numCloud].get();
-    GrainCluster *gc = cloud->cloud.get();
-    GrainClusterVis *gv = cloud->view.get();
+    GrainCluster *gc = selectedCloudSave->cloud.get();
+    GrainClusterVis *gv = selectedCloudSave->view.get();
 
     std::ostream &out = std::cout;
-    out << "Grain Cloud " << numCloud << ":";
+    out << "Grain Cloud " << gc->getId() << "\n";
     gc->describe(out);
 
     QJsonObject objGrain;

--- a/sources/model/Scene.h
+++ b/sources/model/Scene.h
@@ -70,6 +70,8 @@ public:
     // init default cloud params
     void initDefaultCloudParams();
 
+    int getNumCloud(SceneCloud *cloudForNum);
+
 
     SceneSound *selectedSound();
     SceneCloud *selectedCloud();

--- a/sources/model/Scene.h
+++ b/sources/model/Scene.h
@@ -50,11 +50,13 @@ public:
 
     // window to choose a scene file
     static std::string askNameScene(FileDirection direction);
-
+    static std::string askNameCloud(FileDirection direction);
     void clear();
 
     bool load(QFile &sceneFile);
+    bool loadCloudDefault(QFile &cloudFile);
     bool save(QFile &sceneFile);
+    bool saveCloud(QFile &cloudFile, int numCloud);
 
     bool loadSampleSet(bool interactive);
     AudioFile *loadNewSample(const std::string &path);
@@ -64,6 +66,10 @@ public:
 
     void addSoundRect(AudioFile *sample);
     void addNewCloud(int numVoices);
+
+    // init default cloud params
+    void initDefaultCloudParams();
+
 
     SceneSound *selectedSound();
     SceneCloud *selectedCloud();

--- a/sources/model/Scene.h
+++ b/sources/model/Scene.h
@@ -56,7 +56,7 @@ public:
     bool load(QFile &sceneFile);
     bool loadCloudDefault(QFile &cloudFile);
     bool save(QFile &sceneFile);
-    bool saveCloud(QFile &cloudFile, int numCloud);
+    bool saveCloud(QFile &cloudFile, SceneCloud *selectedCloudSave);
 
     bool loadSampleSet(bool interactive);
     AudioFile *loadNewSample(const std::string &path);

--- a/sources/theglobals.h
+++ b/sources/theglobals.h
@@ -85,5 +85,26 @@ enum class FileDirection {
 
 // scenes
 static const char *g_extensionScene = ".scn";
+static const char *g_extensionCloud = ".cld";
+// clouds
+//typedef struct CloudParams CloudParams;
+struct CloudParams
+{
+    // cluster params
+    float duration;
+    float overlap;
+    float pitch;
+    float pitchLFOFreq;
+    float pitchLFOAmount;
+    int dirMode;
+    int windowType;
+    int spatialMode;
+    int chanelLocation;
+    float volumeDB;
+    int numVoices;
+    bool activateState;
+    float xRandExtent;
+    float yRandExtent;
+};
 
 #endif

--- a/sources/visual/GrainClusterVis.cpp
+++ b/sources/visual/GrainClusterVis.cpp
@@ -75,8 +75,10 @@ GrainClusterVis::GrainClusterVis(float x, float y, unsigned int numVoices,
 
 
     // randomness params
-    xRandExtent = 3.0;
-    yRandExtent = 3.0;
+    //xRandExtent = 3.0;
+    //yRandExtent = 3.0;
+    xRandExtent = g_defaultCloudParams.xRandExtent;
+    yRandExtent = g_defaultCloudParams.yRandExtent;
 
     // init add and remove flags to false
     addFlag = false;

--- a/sources/visual/GrainClusterVis.h
+++ b/sources/visual/GrainClusterVis.h
@@ -38,14 +38,15 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #endif
-
 #include <vector>
 #include <memory>
 #include <iostream>
+#include "theglobals.h"
 class SceneSound;
 class GrainVis;
 
 typedef std::vector<std::unique_ptr<SceneSound>> VecSceneSound;
+extern CloudParams g_defaultCloudParams;
 
 // VISUALIZATION/CONTROLLER
 class GrainClusterVis {


### PR DESCRIPTION
les fonctions ajoutées permettent, à l'appui sur la touche "c", si un cloud est sélectionné,  de sauvegarder tous ses parametres dans un fichier .cld (à part le placement x,y), en respectant le format déjà utilisé dans la sauvegarde des scenes.
une ligne du menu fichier a été ajoutée pour permettre de charger un fichier .cld afin de faire des pamametres de clouds qui y etaient stockés les valeurs par défaut qui seront désormais appliquées aux nouveaux clouds créés dans la scene.
les valeurs par defaut sont maintenant stockées dans une structure globale, et initialisées à la creation d'une scene.
