### PR TITLE
normalisation noms d'entites, sauvegarde Id de cloud dans la scene, …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,11 @@ add_executable(Frontieres WIN32
   sources/interface/StartDialog.cpp
   sources/dsp/Window.cpp
   sources/model/AudioFileSet.cpp
-  sources/model/GrainVoice.cpp
-  sources/model/GrainCluster.cpp
+  sources/model/Grain.cpp
+  sources/model/Cloud.cpp
   sources/model/Scene.cpp
   sources/visual/GrainVis.cpp
-  sources/visual/GrainClusterVis.cpp
+  sources/visual/CloudVis.cpp
   sources/visual/SoundRect.cpp
   sources/utility/GTime.cpp
   libraries/QtFont3D/QtFont3D.cpp

--- a/Frontieres.pro
+++ b/Frontieres.pro
@@ -46,11 +46,11 @@ SOURCES += \
   sources/interface/StartDialog.cpp \
   sources/dsp/Window.cpp \
   sources/model/AudioFileSet.cpp \
-  sources/model/GrainVoice.cpp \
-  sources/model/GrainCluster.cpp \
+  sources/model/Grain.cpp \
+  sources/model/Cloud.cpp \
   sources/model/Scene.cpp \
   sources/visual/GrainVis.cpp \
-  sources/visual/GrainClusterVis.cpp \
+  sources/visual/CloudVis.cpp \
   sources/visual/SoundRect.cpp \
   sources/utility/GTime.cpp \
   libraries/Stk.cpp \
@@ -68,11 +68,11 @@ HEADERS += \
   sources/interface/StartDialog.h \
   sources/dsp/Window.h \
   sources/model/AudioFileSet.h \
-  sources/model/GrainCluster.h \
-  sources/model/GrainVoice.h \
+  sources/model/Cloud.h \
+  sources/model/Grain.h \
   sources/model/Scene.h \
   sources/visual/GrainVis.h \
-  sources/visual/GrainClusterVis.h \
+  sources/visual/CloudVis.h \
   sources/visual/SoundRect.h \
   sources/utility/GTime.h \
   libraries/RtMidi.h \

--- a/sources/Frontieres.cpp
+++ b/sources/Frontieres.cpp
@@ -64,10 +64,10 @@
 
 // graphics related
 #include "visual/SoundRect.h"
-#include "visual/GrainClusterVis.h"
+#include "visual/CloudVis.h"
 
 // audio related
-#include "model/GrainCluster.h"
+#include "model/Cloud.h"
 #include "model/Scene.h"
 
 // time
@@ -225,7 +225,7 @@ int audioCallback(void *outputBuffer, void *inputBuffer, unsigned int numFrames,
         if (lock.owns_lock()) {
             Scene *scene = ::currentScene;
             for (int i = 0, n = scene->m_clouds.size(); i < n; i++) {
-                GrainCluster &theCloud = *scene->m_clouds[i]->cloud;
+                Cloud &theCloud = *scene->m_clouds[i]->cloud;
                 theCloud.nextBuffer(out, numFrames);
             }
         }
@@ -416,8 +416,8 @@ void printParam()
     int screenHeight = screen->height();
 
     if (selectedCloud) {
-        GrainClusterVis &theCloudVis = *selectedCloud->view;
-        GrainCluster &theCloud = *selectedCloud->cloud;
+        CloudVis &theCloudVis = *selectedCloud->view;
+        Cloud &theCloud = *selectedCloud->cloud;
 
         // float cloudX = theCloudVis.getX();
         // float cloudY = theCloudVis.getY();
@@ -429,8 +429,8 @@ void printParam()
 
         switch (currentParam) {
         case NUMGRAINS:
-            myValue = _S("", "Voices: ");
-            sinput << theCloud.getNumVoices();
+            myValue = _S("", "Grains: ");
+            sinput << theCloud.getNumGrains();
             myValue = myValue + sinput.str();
             draw_string((GLfloat)mouseX, (GLfloat)(screenHeight - mouseY), 0.0,
                         myValue.c_str(), 100.0f);
@@ -603,7 +603,9 @@ void printParam()
             //            myValue = "Duration (ms): " + theCloud->getDurationMs();
             break;
         case NUM:
-            myValue = _S("", "Cloud Num: ") + std::to_string(currentScene->getNumCloud(selectedCloud)+1);
+            myValue = _S("", "Cloud ID/Num: ")
+                    + std::to_string(theCloud.getId())
+                    + "/" + std::to_string(currentScene->getNumCloud(selectedCloud)+1);
             draw_string((GLfloat)mouseX, (GLfloat)(screenHeight - mouseY), 0.0,
                         myValue.c_str(), 100.0f);
             break;

--- a/sources/interface/MyGLWindow.cpp
+++ b/sources/interface/MyGLWindow.cpp
@@ -22,9 +22,9 @@
 #include "interface/MyGLWindow.h"
 #include "interface/MyGLApplication.h"
 #include "ui_MyGLWindow.h"
-#include "model/GrainCluster.h"
+#include "model/Cloud.h"
 #include "model/Scene.h"
-#include "visual/GrainClusterVis.h"
+#include "visual/CloudVis.h"
 #include "visual/SoundRect.h"
 #include "Frontieres.h"
 #include <QtFont3D.h>
@@ -152,9 +152,9 @@ void MyGLScreen::paintGL()
             sv.draw();
         }
 
-        // render grain clouds if they exist
+        // render clouds if they exist
         for (int i = 0, n = scene->m_clouds.size(); i < n; i++) {
-            GrainClusterVis &gv = *scene->m_clouds[i]->view;
+            CloudVis &gv = *scene->m_clouds[i]->view;
             gv.draw();
         }
 
@@ -165,9 +165,6 @@ void MyGLScreen::paintGL()
     else {
         printUsage();
     }
-
-
-    // printUsage();
 
     // POP ---//restore state
     glPopMatrix();
@@ -211,9 +208,9 @@ void MyGLScreen::mousePressEvent(QMouseEvent *event)
 
         lastDragX = veryHighNumber;
         lastDragY = veryHighNumber;
-        // first check grain clouds to see if we have selection
+        // first check clouds to see if we have selection
         for (int i = 0, n = scene->m_clouds.size(); i < n; i++) {
-            GrainClusterVis &gv = *scene->m_clouds[i]->view;
+            CloudVis &gv = *scene->m_clouds[i]->view;
             if (gv.select(mouseX, mouseY)) {
                 gv.setSelectState(true);
                 scene->m_selectedCloud = i;
@@ -225,7 +222,7 @@ void MyGLScreen::mousePressEvent(QMouseEvent *event)
         // clear selection buffer
         scene->m_selectionIndices.clear();
         scene->m_selectionIndex = 0;
-        // if grain cloud is not selected - search for rectangle selection
+        // if cloud is not selected - search for rectangle selection
         if (!scene->selectedCloud()) {
             // search for selections
             resizeDir = false;  // set resize direction to horizontal
@@ -360,25 +357,10 @@ void MyGLScreen::mousePassiveMoveEvent(QMouseEvent *event)
             break;
         }
     }
-    //            case NUMGRAINS:
-    //                break;
-    //            case DURATION:
-    //                grainCloud->at(selectedCloud)->setDurationMs((mouseY/screenHeight)*4000.0f);
-    //
-    //            default:
-    //                break;
-    //        }
-    //    }
-    // process rectangles
-    //    for (int i = 0; i < soundViews.size(); i++)
-    //        soundViews[i]->procMovement(x, y);
-    //
 }
 
 void MyGLScreen::keyPressEvent(QKeyEvent *event)
 {
-    //qDebug() << event;
-
     static const float sidewaysMoveSpeed = 10.0f;
     static const float upDownMoveSpeed = 10.0f;
 
@@ -512,7 +494,6 @@ void MyGLScreen::keyPressEvent(QKeyEvent *event)
             }
             paramString = "";
         }
-        // cout << "enter key caught" << endl;
         break;
 
 
@@ -606,13 +587,8 @@ void MyGLScreen::keyPressEvent(QKeyEvent *event)
         if (selectedSound) {
             selectedSound->view->toggleOrientation();
         }
-        // cerr << "Looking from the front" << endl;
         break;
     case Qt::Key_P:  // waveform display on/off
-
-        //            for (int i = 0; i < soundViews.size();i++){
-        //                soundViews[i]->toggleWaveDisplay();
-        //            }
         break;
     case Qt::Key_W:  // window editing for grain
         paramString = "";
@@ -685,21 +661,18 @@ void MyGLScreen::keyPressEvent(QKeyEvent *event)
             break;
         }
         else {
-            int numVoices = 8;  // initial number of voices
+            int numGrains = 8;  // initial number of grains
             if (selectedCloud) {
                 if (!scene->m_clouds.empty()) {
                     selectedCloud->view->setSelectState(false);
                 }
             }
-            scene->addNewCloud(numVoices);
+            scene->addNewCloud(numGrains);
             scene->m_selectedCloud = scene->m_clouds.size() - 1;
         }
-        //                        cout << "cloud added" << endl;
-        // grainControl->newCluster(mouseX,mouseY,1);
-
         break;
     }
-    case Qt::Key_V:  // grain voices (add, delete)
+    case Qt::Key_V:  // grains (add, delete)
         paramString = "";
         if (currentParam != NUMGRAINS) {
             currentParam = NUMGRAINS;
@@ -708,7 +681,6 @@ void MyGLScreen::keyPressEvent(QKeyEvent *event)
             if (modkey == Qt::ShiftModifier) {
                 if (selectedCloud) {
                     selectedCloud->cloud->removeGrain();
-                    // cout << "grain removed" << endl;
                 }
             }
             else {

--- a/sources/model/Cloud.h
+++ b/sources/model/Cloud.h
@@ -21,14 +21,14 @@
 
 
 //
-//  GrainCluster.h
+//  Cloud.h
 //  Frontières
 //
 //  Created by Christopher Carlson on 11/15/11.
 //
 
-#ifndef GRAIN_CLUSTER_H
-#define GRAIN_CLUSTER_H
+#ifndef CLOUD_H
+#define CLOUD_H
 
 #include "theglobals.h"
 #include <Stk.h>
@@ -44,7 +44,7 @@
 #include <QDir>
 #include <QJsonObject>
 #include <QJsonArray>
-class GrainVoice;
+class Grain;
 struct SceneSound;
 
 typedef std::vector<std::unique_ptr<SceneSound>> VecSceneSound;
@@ -63,26 +63,26 @@ using namespace std;
 
 
 // forward declarations
-class GrainCluster;
-class GrainClusterVis;
+class Cloud;
+class CloudVis;
 
 // ids
-static unsigned int clusterId = 0;
+static unsigned int cloudId = 0;
 extern CloudParams g_defaultCloudParams;
 // class interface
-class GrainCluster {
+class Cloud {
 
 public:
     // destructor
-    virtual ~GrainCluster();
+    virtual ~Cloud();
 
     // constructor
-    GrainCluster(VecSceneSound *soundSet, float theNumVoices);
+    Cloud(VecSceneSound *soundSet, float theNumGrains);
 
     // compute next buffer of audio (accumulate from grains)
     void nextBuffer(double *accumBuff, unsigned int numFrames);
 
-    // CLUSTER PARAMETER accessors/mutators
+    // CLOUD PARAMETER accessors/mutators
     // set duration for all grains
     void setDurationMs(float theDur);
     float getDurationMs();
@@ -106,7 +106,7 @@ public:
     void setDirection(int dirMode);
     int getDirection();
 
-    // add/remove grain voice
+    // add/remove grain
     void addGrain();
     void removeGrain();
 
@@ -125,11 +125,12 @@ public:
     float getVolumeDb();
 
 
-    // get unique id of grain cluster
+    // get unique id of cloud
     unsigned int getId();
+    void setId(int cloudId);
 
     // register visualization
-    void registerVis(GrainClusterVis *myVis);
+    void registerVis(CloudVis *myVis);
 
     // turn on/off
     void toggleActive();
@@ -137,8 +138,8 @@ public:
     bool getActiveState();
 
 
-    // return number of voices
-    unsigned int getNumVoices();
+    // return number of Grains
+    unsigned int getNumGrains();
 
     // update after a change of sound set
     void updateSoundSet();
@@ -150,7 +151,7 @@ protected:
     // update internal trigger point
     void updateBangTime();
 
-    // spatialization - get new channel multiplier buffer to pass to grain voice instance
+    // spatialization - get new channel multiplier buffer to pass to grain instance
     void updateSpatialization();
 
 private:
@@ -162,7 +163,7 @@ private:
     unsigned long local_time;  // internal clock
     double startTime;  // instantiation time
     double bang_time;  // trigger time for next grain
-    unsigned int nextGrain;  // grain voice index
+    unsigned int nextGrain;  // grain index
 
     // spatialization vars
     int currentAroundChan;
@@ -170,7 +171,7 @@ private:
     int side;
 
     // registered visualization
-    GrainClusterVis *myVis;
+    CloudVis *myVis;
 
     // spatialization
     double *channelMults;
@@ -181,12 +182,12 @@ private:
     float volumeDb, normedVol;
 
     // vector of grains
-    vector<GrainVoice *> myGrains;
+    vector<Grain *> myGrains;
 
-    // number of grains in this cluster
-    unsigned int numVoices;
+    // number of grains in this cloud
+    unsigned int numGrains;
 
-    // cluster params
+    // cloud params
     float overlap, overlapNorm, pitch, duration, pitchLFOFreq, pitchLFOAmount;
     int myDirMode, windowType;
 

--- a/sources/model/Grain.cpp
+++ b/sources/model/Grain.cpp
@@ -21,13 +21,13 @@
 
 
 //
-//  GrainVoice.cpp
+//  Grain.cpp
 //  Frontières
 //
 //  Created by Christopher Carlson on 11/20/11.
 //
 
-#include "model/GrainVoice.h"
+#include "model/Grain.h"
 #include "model/AudioFileSet.h"
 #include "model/Scene.h"
 #include "dsp/Window.h"
@@ -40,7 +40,7 @@ extern unsigned int samp_rate;
 //-----------------------------------------------------------------------------
 // Destructor
 //-----------------------------------------------------------------------------
-GrainVoice::~GrainVoice()
+Grain::~Grain()
 {
     if (chanMults)
         delete[] chanMults;
@@ -54,7 +54,7 @@ GrainVoice::~GrainVoice()
 // Constructor
 //-----------------------------------------------------------------------------
 
-GrainVoice::GrainVoice(VecSceneSound *soundSet, float durationMs, float thePitch)
+Grain::Grain(VecSceneSound *soundSet, float durationMs, float thePitch)
 {
 
 
@@ -123,10 +123,10 @@ GrainVoice::GrainVoice(VecSceneSound *soundSet, float durationMs, float thePitch
 // Turn on grain.
 // input args = position and volume vectors in sound rect space
 // returns whether or not grain is awaiting play.
-// parent cloud will wait to play this voice if the voice is still
+// parent cloud will wait to play this grain if the grain is still
 // this should not be an issue unless the overlap value is erroneous
 //-----------------------------------------------------------------------------
-bool GrainVoice::playMe(double *startPositions, double *startVols)
+bool Grain::playMe(double *startPositions, double *startVols)
 {
 
     if (playingState == false) {
@@ -166,7 +166,7 @@ bool GrainVoice::playMe(double *startPositions, double *startVols)
 //-----------------------------------------------------------------------------
 // Find out if grain is currently on
 //-----------------------------------------------------------------------------
-bool GrainVoice::isPlaying()
+bool Grain::isPlaying()
 {
     return playingState;
 }
@@ -175,7 +175,7 @@ bool GrainVoice::isPlaying()
 //-----------------------------------------------------------------------------
 // Set channel multipliers
 //-----------------------------------------------------------------------------
-void GrainVoice::setChannelMultipliers(double *multipliers)
+void Grain::setChannelMultipliers(double *multipliers)
 {
     for (int i = 0; i < MY_CHANNELS; i++) {
         queuedChanMults[i] = multipliers[i];
@@ -187,7 +187,7 @@ void GrainVoice::setChannelMultipliers(double *multipliers)
 //-----------------------------------------------------------------------------
 // Set channel multipliers
 //-----------------------------------------------------------------------------
-void GrainVoice::setVolume(float theVolNormed)
+void Grain::setVolume(float theVolNormed)
 {
     float pVol = fabs(theVolNormed);
     queuedLocalAtten = pVol;
@@ -196,7 +196,7 @@ void GrainVoice::setVolume(float theVolNormed)
 //-----------------------------------------------------------------------------
 // Get channel multipliers
 //-----------------------------------------------------------------------------
-float GrainVoice::getVolume()
+float Grain::getVolume()
 {
     return localAtten;
 }
@@ -204,7 +204,7 @@ float GrainVoice::getVolume()
 //-----------------------------------------------------------------------------
 // Set duration (effective on next trigger)
 //-----------------------------------------------------------------------------
-void GrainVoice::setDurationMs(float dur)
+void Grain::setDurationMs(float dur)
 {
     // get absolute value
     queuedDuration = fabs(dur);
@@ -216,7 +216,7 @@ void GrainVoice::setDurationMs(float dur)
 //-----------------------------------------------------------------------------
 // Set pitch (effective on next trigger)
 //-----------------------------------------------------------------------------
-void GrainVoice::setPitch(float newPitch)
+void Grain::setPitch(float newPitch)
 {
     // get absolute value
     queuedPitch = newPitch;
@@ -224,7 +224,7 @@ void GrainVoice::setPitch(float newPitch)
         newParam = true;
 }
 
-float GrainVoice::getPitch()
+float Grain::getPitch()
 {
     if (queuedPitch != pitch)
         return queuedPitch;
@@ -236,7 +236,7 @@ float GrainVoice::getPitch()
 //-----------------------------------------------------------------------------
 // Update params
 //-----------------------------------------------------------------------------
-void GrainVoice::updateParams()
+void Grain::updateParams()
 {
     // update parameter set
 
@@ -280,7 +280,7 @@ void GrainVoice::updateParams()
 // Set window type (effective on next trigger)
 //-----------------------------------------------------------------------------
 
-void GrainVoice::setWindow(unsigned int theType)
+void Grain::setWindow(unsigned int theType)
 {
     queuedWindowType = theType;
     if (queuedWindowType != windowType)
@@ -290,7 +290,7 @@ void GrainVoice::setWindow(unsigned int theType)
 //-----------------------------------------------------------------------------
 // Update after a change of sound set
 //-----------------------------------------------------------------------------
-void GrainVoice::updateSoundSet()
+void Grain::updateSoundSet()
 {
     // get number of loaded sounds
     unsigned numSounds = (unsigned)theSounds->size();
@@ -313,7 +313,7 @@ void GrainVoice::updateSoundSet()
 // Set direction (effective on next trigger)
 //-----------------------------------------------------------------------------
 
-void GrainVoice::setDirection(float thedir)
+void Grain::setDirection(float thedir)
 {
     queuedDirection = thedir;
     if (queuedDirection != direction)
@@ -326,7 +326,7 @@ void GrainVoice::setDirection(float thedir)
 //-----------------------------------------------------------------------------
 
 
-void GrainVoice::nextBuffer(double *accumBuff, unsigned int numFrames,
+void Grain::nextBuffer(double *accumBuff, unsigned int numFrames,
                             unsigned int bufferOffset, int name)
 {
 
@@ -491,7 +491,7 @@ void GrainVoice::nextBuffer(double *accumBuff, unsigned int numFrames,
 
             // spatialize output
             for (int k = 0; k < MY_CHANNELS; k++) {
-                // preserve stereo waveform L/R for now and just sample alternate channels in "AROUND" case (see GrainCluster.cpp updateSpatialization routine)
+                // preserve stereo waveform L/R for now and just sample alternate channels in "AROUND" case (see Cloud.cpp updateSpatialization routine)
                 if ((k % 2) == 0) {
                     accumBuff[(bufferOffset + i) * MY_CHANNELS + k] +=
                         (stereoLeftVal + monoWaveVal) * chanMults[k] * localAtten;

--- a/sources/model/Grain.h
+++ b/sources/model/Grain.h
@@ -21,14 +21,14 @@
 
 
 //
-//  GrainVoice.h
+//  Grain.h
 //  Frontières
 //
 //  Created by Christopher Carlson on 11/13/11.
 //
 
-#ifndef GRAINVOICE_H
-#define GRAINVOICE_H
+#ifndef GRAIN_H
+#define GRAIN_H
 
 #include <vector>
 #include <memory>
@@ -47,7 +47,7 @@
 
 // forward declarations
 class AudioFile;
-class GrainVoice;
+class Grain;
 class GrainVis;
 class SceneSound;
 
@@ -55,14 +55,14 @@ typedef std::vector<std::unique_ptr<SceneSound>> VecSceneSound;
 
 
 // AUDIO CLASS
-class GrainVoice {
+class Grain {
 
 public:
     // destructor
-    virtual ~GrainVoice();
+    virtual ~Grain();
 
     // constructor
-    GrainVoice(VecSceneSound *soundSet, float durationMs, float thePitch);
+    Grain(VecSceneSound *soundSet, float durationMs, float thePitch);
 
     // dump samples into next buffer
     void nextBuffer(double *accumBuff, unsigned int numFrames,

--- a/sources/model/Scene.h
+++ b/sources/model/Scene.h
@@ -31,8 +31,8 @@ struct SceneSound;
 struct SceneCloud;
 struct AudioFile;
 struct SoundRect;
-struct GrainCluster;
-struct GrainClusterVis;
+struct Cloud;
+struct CloudVis;
 class AudioFileSet;
 class QFile;
 
@@ -65,12 +65,12 @@ public:
     void addAudioPath(const std::string &path);
 
     void addSoundRect(AudioFile *sample);
-    void addNewCloud(int numVoices);
+    void addNewCloud(int numGrains);
 
     // init default cloud params
     void initDefaultCloudParams();
 
-    int getNumCloud(SceneCloud *cloudForNum);
+    int getNumCloud(SceneCloud *cloudCurrent);
 
 
     SceneSound *selectedSound();
@@ -103,8 +103,8 @@ struct SceneSound {
 };
 
 struct SceneCloud {
-    std::unique_ptr<GrainCluster> cloud;
-    std::unique_ptr<GrainClusterVis> view;
+    std::unique_ptr<Cloud> cloud;
+    std::unique_ptr<CloudVis> view;
 
     ~SceneCloud();
 };

--- a/sources/theglobals.h
+++ b/sources/theglobals.h
@@ -90,7 +90,7 @@ static const char *g_extensionCloud = ".cld";
 //typedef struct CloudParams CloudParams;
 struct CloudParams
 {
-    // cluster params
+    // cloud params
     float duration;
     float overlap;
     float pitch;
@@ -101,7 +101,7 @@ struct CloudParams
     int spatialMode;
     int chanelLocation;
     float volumeDB;
-    int numVoices;
+    int numGrains;
     bool activateState;
     float xRandExtent;
     float yRandExtent;

--- a/sources/visual/CloudVis.cpp
+++ b/sources/visual/CloudVis.cpp
@@ -21,13 +21,13 @@
 
 
 //
-//  GrainClusterVis.cpp
+//  CloudVis.cpp
 //  Frontières
 //
 //  Created by Christopher Carlson on 11/15/11.
 //
 
-#include "visual/GrainClusterVis.h"
+#include "visual/CloudVis.h"
 #include "visual/GrainVis.h"
 #include "visual/SoundRect.h"
 #include "model/Scene.h"
@@ -51,13 +51,13 @@
 // GRAPHICS
 //-----------------------------------------------------------------------------------------------
 
-GrainClusterVis::~GrainClusterVis()
+CloudVis::~CloudVis()
 {
     for (GrainVis *vis : myGrainsV)
         delete vis;
 }
 
-GrainClusterVis::GrainClusterVis(float x, float y, unsigned int numVoices,
+CloudVis::CloudVis(float x, float y, unsigned int numGrainsVis,
                                  VecSceneSound *rects)
 {
     // get screen width and height
@@ -66,17 +66,10 @@ GrainClusterVis::GrainClusterVis(float x, float y, unsigned int numVoices,
     screenHeight = screen->height();
 
     startTime = GTime::instance().sec;
-    // cout << "cluster started at : " << startTime << " sec " << endl;
+
     gcX = x;
     gcY = y;
 
-    //    cout << "cluster x" << gcX << endl;
-    //    cout << "cluster y" << gcY  << endl;
-
-
-    // randomness params
-    //xRandExtent = 3.0;
-    //yRandExtent = 3.0;
     xRandExtent = g_defaultCloudParams.xRandExtent;
     yRandExtent = g_defaultCloudParams.yRandExtent;
 
@@ -93,11 +86,11 @@ GrainClusterVis::GrainClusterVis(float x, float y, unsigned int numVoices,
     // pointer to landscape visualization objects
     theLandscape = rects;
 
-    for (int i = 0; i < numVoices; i++) {
+    for (int i = 0; i < numGrainsVis; i++) {
         myGrainsV.push_back(new GrainVis(gcX, gcY));
     }
 
-    numGrains = numVoices;
+    numGrains = numGrainsVis;
 
 
     // visualization stuff
@@ -108,13 +101,13 @@ GrainClusterVis::GrainClusterVis(float x, float y, unsigned int numVoices,
     targetRad = maxSelRad;
 }
 
-void GrainClusterVis::setDuration(float dur)
+void CloudVis::setDuration(float dur)
 {
     freq = 1000.0 / dur;
 }
 
 // print information
-void GrainClusterVis::describe(std::ostream &out)
+void CloudVis::describe(std::ostream &out)
 {
     out << "- X : " << getX() << "\n";
     out << "- Y : " << getY() << "\n";
@@ -122,18 +115,18 @@ void GrainClusterVis::describe(std::ostream &out)
     out << "- Y extent : " << getYRandExtent() << "\n";
 }
 
-// return cluster x
-float GrainClusterVis::getX()
+// return cloud x
+float CloudVis::getX()
 {
     return gcX;
 }
-// return cluster y
-float GrainClusterVis::getY()
+// return cloud y
+float CloudVis::getY()
 {
     return gcY;
 }
 
-void GrainClusterVis::draw()
+void CloudVis::draw()
 {
     double t_sec = GTime::instance().sec - startTime;
     // cout << t_sec << endl;
@@ -141,7 +134,7 @@ void GrainClusterVis::draw()
     // if ((g_time -last_gtime) > 50){
     glPushMatrix();
     glTranslatef((GLfloat)gcX, (GLfloat)gcY, 0.0);
-    // Grain cluster representation
+    // Cloud representation
     if (isSelected)
         glColor4f(0.1, 0.7, 0.6, 0.35);
     else
@@ -151,24 +144,9 @@ void GrainClusterVis::draw()
                              sin(2 * PI * (freq * t_sec + 0.125));
     gluDisk(gluNewQuadric(), selRad, selRad + 5.0, 128, 2);
     glPopMatrix();
-
-    // update grain motion;
-    // Individual voices
-
-    // disc version (lower quality, but works on graphics cards that don't support GL_POINT_SMOOTH)
-    //
-    //    for (int i = 0; i < numGrains; i++){
-    //        glPushMatrix();
-    //        myGrainsV[i]->draw(mode);
-    //        glPopMatrix();
-    //    }
-
-    // end disc version
-
-    // point version (preferred)
     glPushMatrix();
     // update grain motion;
-    // Individual voices
+    // Individual grains
     for (int i = 0; i < numGrains; i++) {
         myGrainsV[i]->draw();
     }
@@ -179,7 +157,7 @@ void GrainClusterVis::draw()
 
 
 // get trigger position/volume relative to sound rects for single grain voice
-void GrainClusterVis::getTriggerPos(unsigned int idx, double *playPos,
+void CloudVis::getTriggerPos(unsigned int idx, double *playPos,
                                     double *playVol, float theDur)
 {
     bool trigger = false;
@@ -207,49 +185,49 @@ void GrainClusterVis::getTriggerPos(unsigned int idx, double *playPos,
 }
 
 
-// rand cluster size
-void GrainClusterVis::setFixedXRandExtent(float X)
+// rand cloud size
+void CloudVis::setFixedXRandExtent(float X)
 {
     xRandExtent = X;
 }
 
-void GrainClusterVis::setFixedYRandExtent(float Y)
+void CloudVis::setFixedYRandExtent(float Y)
 {
     yRandExtent = Y;
 }
-void GrainClusterVis::setFixedRandExtent(float X, float Y)
+void CloudVis::setFixedRandExtent(float X, float Y)
 {
     setFixedXRandExtent(X);
     setFixedYRandExtent(Y);
 }
-void GrainClusterVis::setXRandExtent(float mouseX)
+void CloudVis::setXRandExtent(float mouseX)
 {
     xRandExtent = fabs(mouseX - gcX);
     if (xRandExtent < 2.0f)
         xRandExtent = 0.0f;
 }
-void GrainClusterVis::setYRandExtent(float mouseY)
+void CloudVis::setYRandExtent(float mouseY)
 {
     yRandExtent = fabs(mouseY - gcY);
     if (yRandExtent < 2.0f)
         yRandExtent = 0.0f;
 }
-void GrainClusterVis::setRandExtent(float mouseX, float mouseY)
+void CloudVis::setRandExtent(float mouseX, float mouseY)
 {
     setXRandExtent(mouseX);
     setYRandExtent(mouseY);
 }
-float GrainClusterVis::getXRandExtent()
+float CloudVis::getXRandExtent()
 {
     return xRandExtent;
 }
-float GrainClusterVis::getYRandExtent()
+float CloudVis::getYRandExtent()
 {
     return yRandExtent;
 }
 
 //
-void GrainClusterVis::updateCloudPosition(float x, float y)
+void CloudVis::updateCloudPosition(float x, float y)
 {
     float xDiff = x - gcX;
     float yDiff = y - gcY;
@@ -262,7 +240,7 @@ void GrainClusterVis::updateCloudPosition(float x, float y)
     }
 }
 
-void GrainClusterVis::updateGrainPosition(int idx, float x, float y)
+void CloudVis::updateGrainPosition(int idx, float x, float y)
 {
     if (idx < numGrains)
         myGrainsV[idx]->moveTo(x, y);
@@ -270,7 +248,7 @@ void GrainClusterVis::updateGrainPosition(int idx, float x, float y)
 
 
 // check mouse selection
-bool GrainClusterVis::select(float x, float y)
+bool CloudVis::select(float x, float y)
 {
     float xdiff = x - gcX;
     float ydiff = y - gcY;
@@ -281,12 +259,12 @@ bool GrainClusterVis::select(float x, float y)
         return false;
 }
 
-void GrainClusterVis::setSelectState(bool selectState)
+void CloudVis::setSelectState(bool selectState)
 {
     isSelected = selectState;
 }
 
-void GrainClusterVis::addGrain()
+void CloudVis::addGrain()
 {
     //    addFlag = true;
     myGrainsV.push_back(new GrainVis(gcX, gcY));
@@ -294,7 +272,7 @@ void GrainClusterVis::addGrain()
 }
 
 // remove a grain from the cloud (visualization only)
-void GrainClusterVis::removeGrain()
+void CloudVis::removeGrain()
 {
     //    removeFlag = true;
     if (numGrains > 1) {

--- a/sources/visual/CloudVis.h
+++ b/sources/visual/CloudVis.h
@@ -21,14 +21,14 @@
 
 
 //
-//  GrainClusterVis.h
+//  CloudVis.h
 //  Frontières
 //
 //  Created by Christopher Carlson on 11/15/11.
 //
 
-#ifndef GRAIN_CLUSTER_VIS_H
-#define GRAIN_CLUSTER_VIS_H
+#ifndef CLOUD_VIS_H
+#define CLOUD_VIS_H
 
 
 // graphics includes
@@ -49,13 +49,13 @@ typedef std::vector<std::unique_ptr<SceneSound>> VecSceneSound;
 extern CloudParams g_defaultCloudParams;
 
 // VISUALIZATION/CONTROLLER
-class GrainClusterVis {
+class CloudVis {
 public:
     // destructor
-    ~GrainClusterVis();
+    ~CloudVis();
 
-    // constructor (takes center position (x,y), number of voices, sound rectangles)
-    GrainClusterVis(float x, float y, unsigned int numVoices, VecSceneSound *rects);
+    // constructor (takes center position (x,y), number of grains, sound rectangles)
+    CloudVis(float x, float y, unsigned int numGrainsVis, VecSceneSound *rects);
 
     // render
     void draw();
@@ -108,7 +108,7 @@ private:
     float selRad, lambda, maxSelRad, minSelRad, targetRad;
     unsigned int numGrains;
 
-    // grain voice visualizations
+    // grain visualizations
     std::vector<GrainVis *> myGrainsV;
     // registered sound rectangles
     VecSceneSound *theLandscape;


### PR DESCRIPTION
…affichage id et num des clouds sur appui touche "n", quelques lignes de commentaires inutiles enlevées

normalisation des noms d'entités .
- GrainCluster, Cluster, grainCloud deviennent Cloud, aussi bien dans les noms de fichiers que dans les classes, variables, et commentaires (idem pour GrainClusterVis qui devient CoudVis)
- GrainVoice, Voice deviennent Grain, aussi bien dans les noms de fichiers que dans les classes, variables, et commentaires

j'ai ajouté l'id des clouds dans la sauvegarde des scenes

j'ai  fait afficher l'id et le numero d'index des clouds a l'appui sur 'N'

j'en enlevé quelques commentaires inutiles

j'ai aussi change les noms de variables type gc ou gv pout les rendre plus conformes, et plus parlants
