### PR TITLE
normalisation des noms d'entités : Sample et SampleVis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,13 @@ add_executable(Frontieres WIN32
   sources/interface/MyGLWindow.cpp
   sources/interface/StartDialog.cpp
   sources/dsp/Window.cpp
-  sources/model/AudioFileSet.cpp
+  sources/model/Sample.cpp
   sources/model/Grain.cpp
   sources/model/Cloud.cpp
   sources/model/Scene.cpp
   sources/visual/GrainVis.cpp
   sources/visual/CloudVis.cpp
-  sources/visual/SoundRect.cpp
+  sources/visual/SampleVis.cpp
   sources/utility/GTime.cpp
   libraries/QtFont3D/QtFont3D.cpp
   libraries/Stk.cpp

--- a/Frontieres.pro
+++ b/Frontieres.pro
@@ -45,13 +45,13 @@ SOURCES += \
   sources/interface/MyGLWindow.cpp \
   sources/interface/StartDialog.cpp \
   sources/dsp/Window.cpp \
-  sources/model/AudioFileSet.cpp \
+  sources/model/Sample.cpp \
   sources/model/Grain.cpp \
   sources/model/Cloud.cpp \
   sources/model/Scene.cpp \
+  sources/visual/SampleVis.cpp \
   sources/visual/GrainVis.cpp \
   sources/visual/CloudVis.cpp \
-  sources/visual/SoundRect.cpp \
   sources/utility/GTime.cpp \
   libraries/Stk.cpp \
   libraries/RtAudio.cpp \
@@ -67,13 +67,13 @@ HEADERS += \
   sources/interface/MyGLWindow.h \
   sources/interface/StartDialog.h \
   sources/dsp/Window.h \
-  sources/model/AudioFileSet.h \
+  sources/model/Sample.h \
   sources/model/Cloud.h \
   sources/model/Grain.h \
   sources/model/Scene.h \
+  sources/visual/SampleVis.h \
   sources/visual/GrainVis.h \
   sources/visual/CloudVis.h \
-  sources/visual/SoundRect.h \
   sources/utility/GTime.h \
   libraries/RtMidi.h \
   libraries/RtAudio.h \

--- a/sources/Frontieres.cpp
+++ b/sources/Frontieres.cpp
@@ -55,7 +55,7 @@
 
 // audio related
 #include "MyRtAudio.h"
-#include "model/AudioFileSet.h"
+#include "model/Sample.h"
 #include "dsp/Window.h"
 
 // midi related
@@ -63,7 +63,7 @@
 #include <ring_buffer.h>
 
 // graphics related
-#include "visual/SoundRect.h"
+#include "visual/SampleVis.h"
 #include "visual/CloudVis.h"
 
 // audio related
@@ -216,10 +216,10 @@ int audioCallback(void *outputBuffer, void *inputBuffer, unsigned int numFrames,
     }
 
     // cast audio buffers
-    SAMPLE *out = (SAMPLE *)outputBuffer;
-    SAMPLE *in = (SAMPLE *)inputBuffer;
+    BUFFERPREC *out = (BUFFERPREC *)outputBuffer;
+    BUFFERPREC *in = (BUFFERPREC *)inputBuffer;
 
-    memset(out, 0, sizeof(SAMPLE) * numFrames * MY_CHANNELS);
+    memset(out, 0, sizeof(BUFFERPREC) * numFrames * MY_CHANNELS);
     if (menuFlag == false) {
         std::unique_lock<std::mutex> lock(::currentSceneMutex, std::try_to_lock);
         if (lock.owns_lock()) {
@@ -614,14 +614,14 @@ void printParam()
         }
     }
     if (selectedSound) {
-        SoundRect &theSoundRect = *selectedSound->view;
+        SampleVis &theSampleVis = *selectedSound->view;
         string myValue;
         float theA = 0.7f + 0.3 * sin(1.6 * PI * GTime::instance().sec);
         glColor4f(1.0f, 1.0f, 1.0f, theA);
 
         switch (currentParam) {
         case NAME:
-            myValue = _S("", "Sample: ") + theSoundRect.getName();
+            myValue = _S("", "Sample: ") + theSampleVis.getName();
             draw_string((GLfloat)mouseX, (GLfloat)(screenHeight - mouseY), 0.0,
                         myValue.c_str(), 100.0f);
             break;
@@ -880,16 +880,16 @@ int main(int argc, char **argv)
         break;
 
     case StartDialog::Choice_NewScene: {
-        std::vector<AudioFile *> loaded;
+        std::vector<Sample *> loaded;
 
         // attempt to load from user, then system if empty
-        scene->m_audioFiles->loadFileSet(g_audioPathUser, &loaded);
+        scene->m_samples->loadFileSet(g_audioPathUser, &loaded);
         if (loaded.empty())
-            scene->m_audioFiles->loadFileSet(g_audioPathSystem, &loaded);
+            scene->m_samples->loadFileSet(g_audioPathSystem, &loaded);
 
         // add them into the scene
-        for (AudioFile *af : loaded)
-            scene->addSoundRect(af);
+        for (Sample *af : loaded)
+            scene->addSampleVis(af);
 
         break;
     }

--- a/sources/interface/MyGLApplication.cpp
+++ b/sources/interface/MyGLApplication.cpp
@@ -23,7 +23,7 @@
 #include "MyGLWindow.h"
 #include "Frontieres.h"
 #include "I18n.h"
-#include "model/AudioFileSet.h"
+#include "model/Sample.h"
 #include <QTranslator>
 #include <QLibraryInfo>
 #include <QTimer>
@@ -152,10 +152,10 @@ void MyGLApplication::addSound()
         std::unique_lock<std::mutex> lock(::currentSceneMutex);
         Scene *scene = ::currentScene;
 
-        AudioFile *af = scene->loadNewSample(qSoundFile.toStdString());
+        Sample *af = scene->loadNewSample(qSoundFile.toStdString());
         if (af) {
             // add into the scene
-            scene->addSoundRect(af);
+            scene->addSampleVis(af);
 
             // add the file's location into search paths, if not already
             scene->addAudioPath(qSoundDir.path().toStdString());

--- a/sources/interface/MyGLWindow.cpp
+++ b/sources/interface/MyGLWindow.cpp
@@ -25,7 +25,7 @@
 #include "model/Cloud.h"
 #include "model/Scene.h"
 #include "visual/CloudVis.h"
-#include "visual/SoundRect.h"
+#include "visual/SampleVis.h"
 #include "Frontieres.h"
 #include <QtFont3D.h>
 #include <QMouseEvent>
@@ -148,7 +148,7 @@ void MyGLScreen::paintGL()
 
         // render rectangles
         for (int i = 0, n = scene->m_sounds.size(); i < n; i++) {
-            SoundRect &sv = *scene->m_sounds[i]->view;
+            SampleVis &sv = *scene->m_sounds[i]->view;
             sv.draw();
         }
 
@@ -227,7 +227,7 @@ void MyGLScreen::mousePressEvent(QMouseEvent *event)
             // search for selections
             resizeDir = false;  // set resize direction to horizontal
             for (int i = 0, n = scene->m_sounds.size(); i < n; i++) {
-                SoundRect &sv = *scene->m_sounds[i]->view;
+                SampleVis &sv = *scene->m_sounds[i]->view;
                 if (sv.select(mouseX, mouseY) == true) {
                     scene->m_selectionIndices.push_back(i);
                     // sv.setSelectState(true);

--- a/sources/model/Grain.cpp
+++ b/sources/model/Grain.cpp
@@ -28,7 +28,7 @@
 //
 
 #include "model/Grain.h"
-#include "model/AudioFileSet.h"
+#include "model/Sample.h"
 #include "model/Scene.h"
 #include "dsp/Window.h"
 #include "theglobals.h"
@@ -407,7 +407,7 @@ void Grain::nextBuffer(double *accumBuff, unsigned int numFrames,
                 // if sound is in play,sample it
                 if (pos > 0) {
                     // sound vars
-                    AudioFile *af = sounds[nextSound]->sample;
+                    Sample *af = sounds[nextSound]->sample;
                     wave = af->wave;
                     channels = af->channels;
                     frames = af->frames;

--- a/sources/model/Grain.h
+++ b/sources/model/Grain.h
@@ -46,7 +46,7 @@
 
 
 // forward declarations
-class AudioFile;
+class Sample;
 class Grain;
 class GrainVis;
 class SceneSound;

--- a/sources/model/Sample.h
+++ b/sources/model/Sample.h
@@ -21,15 +21,15 @@
 
 
 //
-//  AudioFileSet.h
+//  Sample.h
 //  Frontières
 //
 //  Created by Christopher Carlson on 11/21/11.
 //
 
 
-#ifndef AUDIOFILESET_H
-#define AUDIOFILESET_H
+#ifndef SAMPLE_H
+#define SAMPLE_H
 
 #include <vector>
 #include <string>
@@ -41,11 +41,11 @@ using namespace std;
 
 
 // basic encapsulation of an audio file
-struct AudioFile {
+struct Sample {
 
     // constructor
-    AudioFile(string myName, string thePath, unsigned int numChan,
-              unsigned long numFrames, unsigned int srate, SAMPLE *theWave)
+    Sample(string myName, string thePath, unsigned int numChan,
+              unsigned long numFrames, unsigned int srate, BUFFERPREC *theWave)
     {
         cout << numFrames << endl;
         this->name = myName;
@@ -56,7 +56,7 @@ struct AudioFile {
         this->wave = theWave;
     }
     // destructor
-    ~AudioFile()
+    ~Sample()
     {
         if (wave != NULL) {
             delete[] wave;
@@ -70,38 +70,38 @@ struct AudioFile {
 
     string name;
     string path;
-    SAMPLE *wave;
+    BUFFERPREC *wave;
     unsigned long frames;
     unsigned int channels;
     unsigned int sampleRate;
 };
 
 
-class AudioFileSet {
+class SampleSet {
 
 public:
-    virtual ~AudioFileSet();
+    virtual ~SampleSet();
 
     // constructor
-    AudioFileSet();
+    SampleSet();
 
     // read in all audio files contained in
-    int loadFileSet(const std::string &path, std::vector<AudioFile *> *loaded = nullptr);
+    int loadFileSet(const std::string &path, std::vector<Sample *> *loaded = nullptr);
 
     // load a single file in the collection, or return if the same name already exists
-    AudioFile *loadFile(const std::string &path);
+    Sample *loadFile(const std::string &path);
 
     // remove a single sample from the set
-    void removeSample(AudioFile *sample);
+    void removeSample(Sample *sampleToRemove);
 
     // return the audio vector- note, the intension is for the files to be
     // read only.  if write access is needed in the future - thread safety will
     // need to be considered
-    vector<AudioFile *> *getFileVector();
+    vector<Sample *> *getFileVector();
 
 
 private:
-    vector<AudioFile *> fileSet;
+    vector<Sample *> fileSet;
 };
 
 

--- a/sources/model/Scene.cpp
+++ b/sources/model/Scene.cpp
@@ -24,9 +24,9 @@
 #include "Frontieres.h"
 #include "Cloud.h"
 #include "Grain.h"
-#include "AudioFileSet.h"
+#include "Sample.h"
 #include "I18n.h"
-#include "visual/SoundRect.h"
+#include "visual/SampleVis.h"
 #include "dsp/Window.h"
 #include <QStandardPaths>
 #include <QJsonDocument>
@@ -49,7 +49,7 @@ Scene::~Scene()
 // Constructor
 //-----------------------------------------------------------------------------
 Scene::Scene()
-    : m_audioFiles(new AudioFileSet)
+    : m_samples(new SampleSet)
 {
     initDefaultCloudParams();
 }
@@ -88,7 +88,7 @@ void Scene::clear()
     m_audioPaths.clear();
     m_sounds.clear();
     m_clouds.clear();
-    m_audioFiles.reset(new AudioFileSet);
+    m_samples.reset(new SampleSet);
     m_selectedCloud = -1;
     m_selectedSound = -1;
     m_selectionIndex = 0;
@@ -172,7 +172,7 @@ bool Scene::load(QFile &sceneFile)
         sound->name = name;
         cout << name << "\n";
 
-        SoundRect *sv = new SoundRect();
+        SampleVis *sv = new SampleVis();
         sound->view.reset(sv);
         if ((bool)objSound["orientation"].toInt() != sv->getOrientation())
             sv->toggleOrientation();
@@ -292,7 +292,7 @@ bool Scene::save(QFile &sceneFile)
     cout << m_sounds.size() << "samples : " << "\n";
     for (int i = 0, n = m_sounds.size(); i < n; ++i) {
         SceneSound *sound = m_sounds[i].get();
-        SoundRect *sv = sound->view.get();
+        SampleVis *sv = sound->view.get();
 
         std::ostream &out = std::cout;
         out << "Audio file " << i << ":\n";
@@ -460,13 +460,13 @@ bool Scene::saveCloud(QFile &cloudFile, SceneCloud *selectedCloudSave)
 bool Scene::loadSampleSet(bool interactive)
 {
     // a new sound collection
-    std::unique_ptr<AudioFileSet> audioFiles(new AudioFileSet);
+    std::unique_ptr<SampleSet> samples(new SampleSet);
     // total count of sounds needed
     unsigned numSounds = m_sounds.size();
     // count of sounds left to load
     unsigned numSoundsLeft = numSounds;
     // list of sounds associated with scene
-    std::vector<AudioFile *> soundFileAssoc(numSounds);
+    std::vector<Sample *> soundFileAssoc(numSounds);
 
     // the scene's current audio paths
     std::vector<std::string> audioPaths = m_audioPaths;
@@ -493,12 +493,12 @@ bool Scene::loadSampleSet(bool interactive)
             effectiveAudioPaths.push_back(&g_audioPathSystem);
 
             // locate this file and load
-            AudioFile *af = nullptr;
+            Sample *af = nullptr;
             QString qname = QString::fromStdString(m_sounds[i]->name);
             for (unsigned i = 0, n = effectiveAudioPaths.size(); !af && i < n; ++i) {
                 QDir dir(QString::fromStdString(*effectiveAudioPaths[i]));
                 QString curpath = dir.filePath(qname);
-                af = audioFiles->loadFile(curpath.toStdString());
+                af = samples->loadFile(curpath.toStdString());
 
                 // successful load from a candidate path?
                 if (af && i < candidateAudioPaths.size()) {
@@ -557,9 +557,9 @@ bool Scene::loadSampleSet(bool interactive)
     }
 
     // load all sounds into model
-    m_audioFiles = std::move(audioFiles);
+    m_samples = std::move(samples);
     for (unsigned i = 0, j = 0, n = soundFileAssoc.size(); i < n; ++i) {
-        AudioFile *assoc = soundFileAssoc[i];
+        Sample *assoc = soundFileAssoc[i];
         if (!assoc) {
             // could not load sound for element? remove
             m_sounds.erase(m_sounds.begin() + j);
@@ -584,7 +584,6 @@ bool Scene::loadSampleSet(bool interactive)
 // init default cloud params
 void Scene::initDefaultCloudParams()
 {
-    cout << "entree init default" << endl;
     g_defaultCloudParams.duration = 500.0;
     g_defaultCloudParams.overlap = 1.0f;
     g_defaultCloudParams.pitch = 1.0f;
@@ -599,9 +598,9 @@ void Scene::initDefaultCloudParams()
     g_defaultCloudParams.yRandExtent = 3.0f;
 }
 
-AudioFile *Scene::loadNewSample(const std::string &path)
+Sample *Scene::loadNewSample(const std::string &path)
 {
-    AudioFile *af = m_audioFiles->loadFile(path);
+    Sample *af = m_samples->loadFile(path);
     if (!af) {
         // cannot load
         return nullptr;
@@ -614,7 +613,7 @@ bool Scene::removeSoundAt(unsigned index)
     if (index >= m_sounds.size())
         return false;
 
-    AudioFile *af = m_sounds[index]->sample;
+    Sample *af = m_sounds[index]->sample;
     m_sounds.erase(m_sounds.begin() + index);
 
     for (unsigned i = 0, n = m_clouds.size(); i < n; ++i) {
@@ -626,14 +625,14 @@ bool Scene::removeSoundAt(unsigned index)
     return true;
 }
 
-void Scene::removeSampleIfNotUsed(AudioFile *sample)
+void Scene::removeSampleIfNotUsed(Sample *sampleToRemove)
 {
     bool used = false;
     for (unsigned i = 0, n = m_sounds.size(); !used && i < n; ++i)
-        used = m_sounds[i]->sample == sample;
+        used = m_sounds[i]->sample == sampleToRemove;
     if (!used) {
         std::cout << "Sample is not used, delete\n";
-        m_audioFiles->removeSample(sample);
+        m_samples->removeSample(sampleToRemove);
     }
     else {
         std::cout << "Sample is used, keep\n";
@@ -655,16 +654,16 @@ void Scene::addAudioPath(const std::string &path)
     return;
 }
 
-void Scene::addSoundRect(AudioFile *sample)
+void Scene::addSampleVis(Sample *sampleToAdd)
 {
     SceneSound *sound = new SceneSound;
     m_sounds.emplace_back(sound);
-    sound->name = sample->name;
-    sound->sample = sample;
+    sound->name = sampleToAdd->name;
+    sound->sample = sampleToAdd;
 
-    SoundRect *sv = new SoundRect;
+    SampleVis *sv = new SampleVis;
     sound->view.reset(sv);
-    sv->associateSound(sample->wave, sample->frames, sample->channels, sample->name);
+    sv->associateSound(sampleToAdd->wave, sampleToAdd->frames, sampleToAdd->channels, sampleToAdd->name);
 
     for (unsigned i = 0, n = m_clouds.size(); i < n; ++i) {
         Cloud &cloudToUpdate = *m_clouds[i]->cloud;

--- a/sources/model/Scene.h
+++ b/sources/model/Scene.h
@@ -29,11 +29,11 @@
 #include <memory>
 struct SceneSound;
 struct SceneCloud;
-struct AudioFile;
-struct SoundRect;
+struct Sample;
+struct SampleVis;
 struct Cloud;
 struct CloudVis;
-class AudioFileSet;
+class SampleSet;
 class QFile;
 
 typedef std::vector<std::unique_ptr<SceneSound>> VecSceneSound;
@@ -59,12 +59,12 @@ public:
     bool saveCloud(QFile &cloudFile, SceneCloud *selectedCloudSave);
 
     bool loadSampleSet(bool interactive);
-    AudioFile *loadNewSample(const std::string &path);
+    Sample *loadNewSample(const std::string &path);
     bool removeSoundAt(unsigned index);
-    void removeSampleIfNotUsed(AudioFile *sample);
+    void removeSampleIfNotUsed(Sample *sampleToRemove);
     void addAudioPath(const std::string &path);
 
-    void addSoundRect(AudioFile *sample);
+    void addSampleVis(Sample *sampleToAdd);
     void addNewCloud(int numGrains);
 
     // init default cloud params
@@ -85,7 +85,7 @@ public:
     VecSceneCloud m_clouds;
 
     // sounds
-    std::unique_ptr<AudioFileSet> m_audioFiles;
+    std::unique_ptr<SampleSet> m_samples;
 
     // selection helper vars
     int m_selectedCloud = -1;
@@ -96,8 +96,8 @@ public:
 
 struct SceneSound {
     std::string name;
-    AudioFile *sample = nullptr;
-    std::unique_ptr<SoundRect> view;
+    Sample *sample = nullptr;
+    std::unique_ptr<SampleVis> view;
 
     ~SceneSound();
 };

--- a/sources/theglobals.h
+++ b/sources/theglobals.h
@@ -35,8 +35,8 @@
 #include <stdlib.h>
 
 
-// create sample datatype
-#define SAMPLE double
+// create BUFFERPREC datatype
+#define BUFFERPREC double
 // create rtaudio format
 #define MY_FORMAT RTAUDIO_FLOAT64
 // create soxr format

--- a/sources/visual/CloudVis.cpp
+++ b/sources/visual/CloudVis.cpp
@@ -29,7 +29,7 @@
 
 #include "visual/CloudVis.h"
 #include "visual/GrainVis.h"
-#include "visual/SoundRect.h"
+#include "visual/SampleVis.h"
 #include "model/Scene.h"
 #include "utility/GTime.h"
 
@@ -161,7 +161,7 @@ void CloudVis::getTriggerPos(unsigned int idx, double *playPos,
                                     double *playVol, float theDur)
 {
     bool trigger = false;
-    SoundRect *theRect = NULL;
+    SampleVis *theRect = NULL;
     if (idx < myGrainsV.size()) {
         GrainVis *theGrain = myGrainsV[idx];
         // TODO: motion models

--- a/sources/visual/SampleVis.cpp
+++ b/sources/visual/SampleVis.cpp
@@ -30,7 +30,7 @@
 
 // TODO:  set and show name implementation
 
-#include "SoundRect.h"
+#include "SampleVis.h"
 #include "utility/GTime.h"
 
 // TODO avoid this
@@ -38,14 +38,14 @@
 #include "interface/MyGLWindow.h"
 
 // destructor
-SoundRect::~SoundRect()
+SampleVis::~SampleVis()
 {
     myBuff = NULL;
 }
 
 
 // constructor
-SoundRect::SoundRect()
+SampleVis::SampleVis()
 {
     // get screen width and height
     MyGLScreen *screen = theApplication->GLwindow()->screen();
@@ -87,7 +87,7 @@ SoundRect::SoundRect()
 
 
 // other intialization code
-void SoundRect::init()
+void SampleVis::init()
 {
 
     // selection state
@@ -126,12 +126,12 @@ void SoundRect::init()
 
 
 // set selection (highlight)
-void SoundRect::setSelectState(bool state)
+void SampleVis::setSelectState(bool state)
 {
     isSelected = state;
 }
 // determine if mouse click is in selection range
-bool SoundRect::select(float x, float y)
+bool SampleVis::select(float x, float y)
 {
 
     // check selection
@@ -146,26 +146,26 @@ bool SoundRect::select(float x, float y)
 }
 
 // process mouse motion during selection
-void SoundRect::move(float xDiff, float yDiff)
+void SampleVis::move(float xDiff, float yDiff)
 {
     rX = rX + xDiff;
     rY = rY + yDiff;
     updateCorners(rWidth, rHeight);
 }
 
-void SoundRect::setXY(float x, float y)
+void SampleVis::setXY(float x, float y)
 {
     rX = x;
     rY = y;
     updateCorners(rWidth, rHeight);
 }
 
-bool SoundRect::getOrientation()
+bool SampleVis::getOrientation()
 {
     return orientation;
 }
 
-void SoundRect::toggleOrientation()
+void SampleVis::toggleOrientation()
 {
     orientation = !orientation;
     setWidthHeight(rHeight, rWidth);
@@ -173,7 +173,7 @@ void SoundRect::toggleOrientation()
 
 
 // color randomizer + alpha (roughly green/blue in color)
-void SoundRect::randColor()
+void SampleVis::randColor()
 {
     // color
     colR = 0.4 + ((float)rand() / RAND_MAX) * 0.3;
@@ -186,7 +186,7 @@ void SoundRect::randColor()
 }
 
 // set width and height
-void SoundRect::setWidthHeight(float width, float height)
+void SampleVis::setWidthHeight(float width, float height)
 {
 
 
@@ -231,29 +231,29 @@ void SoundRect::setWidthHeight(float width, float height)
 }
 
 // getters for width and height
-float SoundRect::getWidth()
+float SampleVis::getWidth()
 {
     return rWidth;
 }
 
-float SoundRect::getHeight()
+float SampleVis::getHeight()
 {
     return rHeight;
 }
 
 // getters for X and Y
-float SoundRect::getX()
+float SampleVis::getX()
 {
     return rX;
 }
 
-float SoundRect::getY()
+float SampleVis::getY()
 {
     return rY;
 }
 
 // update box corners with new width values
-void SoundRect::updateCorners(float width, float height)
+void SampleVis::updateCorners(float width, float height)
 {
     rtop = rY + height * 0.5f;
     rbot = rY - height * 0.5f;
@@ -266,7 +266,7 @@ void SoundRect::updateCorners(float width, float height)
 
 
 // set upsampling for waveform display
-void SoundRect::setUps()
+void SampleVis::setUps()
 {
     float sizeFactor = 10.0f;
     if (orientation == true)
@@ -280,7 +280,7 @@ void SoundRect::setUps()
 
 
 ////process mouse movement/selection
-// void SoundRect::procMovement(int x, int y)
+// void SampleVis::procMovement(int x, int y)
 //{
 //    for (int i = 0; i<5; i++){
 //        if (pickedArray[i] == 1){
@@ -332,7 +332,7 @@ void SoundRect::setUps()
 //    lastY = (float)y;
 //}
 
-void SoundRect::associateSound(double *theBuff, unsigned long buffFrames, unsigned int buffChans, const string &name)
+void SampleVis::associateSound(double *theBuff, unsigned long buffFrames, unsigned int buffChans, const string &name)
 {
 
     myBuff = theBuff;
@@ -347,7 +347,7 @@ void SoundRect::associateSound(double *theBuff, unsigned long buffFrames, unsign
     setWaveDisplayParams();
 }
 
-void SoundRect::setWaveDisplayParams()
+void SampleVis::setWaveDisplayParams()
 {
     if (orientation == true) {
         myBuffInc = myBuffFrames / (ups * rWidth);
@@ -358,7 +358,7 @@ void SoundRect::setWaveDisplayParams()
 }
 
 // draw function
-void SoundRect::draw()
+void SampleVis::draw()
 {
     glPushMatrix();
     // rect properties
@@ -507,7 +507,7 @@ void SoundRect::draw()
 }
 
 
-void SoundRect::toggleWaveDisplay()
+void SampleVis::toggleWaveDisplay()
 {
     pendingBuffState = !pendingBuffState;
     if (pendingBuffState == true)
@@ -515,14 +515,14 @@ void SoundRect::toggleWaveDisplay()
 }
 
 // return id
-// unsigned int SoundRect::getId()
+// unsigned int SampleVis::getId()
 //{
 //    return myId;
 //}
 
 
 // check to see if a coordinate is inside this rectangle
-bool SoundRect::insideMe(float x, float y)
+bool SampleVis::insideMe(float x, float y)
 {
     if ((x > rleft) && (x < rright)) {
         if ((y > rbot) && (y < rtop)) {
@@ -533,7 +533,7 @@ bool SoundRect::insideMe(float x, float y)
 }
 
 // return normalized position values in x and y
-bool SoundRect::getNormedPosition(double *positionsX, double *positionsY,
+bool SampleVis::getNormedPosition(double *positionsX, double *positionsY,
                                   float x, float y, unsigned int idx)
 {
     bool trigger = false;
@@ -550,23 +550,23 @@ bool SoundRect::getNormedPosition(double *positionsX, double *positionsY,
         }
         // cout << positionsX[idx] << ", " << positionsY[idx]<<endl;
         if ((positionsY[idx] < 0.0) || (positionsY[idx] > 1.0))
-            cout << "problem with x trigger pos - see soundrect get normed pos" << endl;
+            cout << "problem with x trigger pos - see sampleVis get normed pos" << endl;
         if ((positionsY[idx] < 0.0) || (positionsY[idx] > 1.0))
-            cout << "problem with x trigger pos - see soundrect get normed pos" << endl;
+            cout << "problem with x trigger pos - see sampleVis get normed pos" << endl;
     }
     return trigger;
 }
 
 
 // set name
-void SoundRect::setName(const string &name)
+void SampleVis::setName(const string &name)
 {
     rName = name;
     return;
 }
 
 // print information
-void SoundRect::describe(std::ostream &out)
+void SampleVis::describe(std::ostream &out)
 {
     out << "- orientation : " << getOrientation() << "\n";
     out << "- height : " << getHeight() << "\n";
@@ -575,7 +575,7 @@ void SoundRect::describe(std::ostream &out)
     out << "- Y : " << getY() << "\n";
 }
 
-const string &SoundRect::getName() const
+const string &SampleVis::getName() const
 {
     return rName;
 }

--- a/sources/visual/SampleVis.h
+++ b/sources/visual/SampleVis.h
@@ -21,14 +21,14 @@
 
 
 //
-//  SoundRect.h
+//  SampleVis.h
 //  Frontières
 //
 //  Created by Christopher Carlson on 11/30/11.
 //
 
-#ifndef SOUNDRECT_H
-#define SOUNDRECT_H
+#ifndef SAMPLEVIS_H
+#define SAMPLEVIS_H
 
 #include "theglobals.h"
 //#include "pt2d.h"
@@ -50,14 +50,14 @@
 // id for this class, which is incremented for each instance
 // static unsigned int boxId = 0;
 
-class SoundRect {
+class SampleVis {
 
 public:
     // destructor
-    virtual ~SoundRect();
+    virtual ~SampleVis();
 
     // constructor (default)
-    SoundRect();
+    SampleVis();
 
     // other object initialization code
     void init();


### PR DESCRIPTION
suite de la normalisation des noms d'entités.
- AudioFile devient Sample
- AudioFileSet devient SampleSet
- SoundRect devient SampleVis

les noms de fichiers sont aussi concernés

ce pull request contient aussi les modifications proposées dans "normalisation des noms d'entites : suppression des "Sample" existants… #42"