### PR TITLE
bugs de la fenetre clouddialog repares

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(Frontieres WIN32
   sources/interface/StartDialog.cpp
   sources/interface/AdsrDialog.cpp
   sources/interface/CloudDialog.cpp
+  sources/interface/OptionsDialog.cpp
   sources/interface/Node.cpp
   sources/dsp/Window.cpp
   sources/model/Adsr.cpp
@@ -79,6 +80,7 @@ target_include_directories(Frontieres
 
 qt5_wrap_ui(Frontieres_UI_SOURCES
   sources/interface/CloudDialog.ui
+  sources/interface/OptionsDialog.ui
   sources/interface/AdsrDialog.ui
   sources/interface/MyGLWindow.ui
   sources/interface/StartDialog.ui)

--- a/Frontieres.pro
+++ b/Frontieres.pro
@@ -10,8 +10,10 @@ DEFINES += __LINUX_ALSASEQ__
 DEFINES += __UNIX_JACK__
 
 INCLUDEPATH += $$PWD/libraries/QtFont3D
-SOURCES += libraries/QtFont3D/QtFont3D.cpp
-HEADERS += libraries/QtFont3D/QtFont3D.h
+SOURCES += libraries/QtFont3D/QtFont3D.cpp \
+    sources/interface/OptionsDialog.cpp
+HEADERS += libraries/QtFont3D/QtFont3D.h \
+    sources/interface/OptionsDialog.h
 
 unix: {
   isEmpty(INSTALL_PREFIX) {
@@ -100,7 +102,8 @@ FORMS += \
   sources/interface/MyGLWindow.ui \
   sources/interface/StartDialog.ui \
   sources/interface/AdsrDialog.ui \
-  sources/interface/CloudDialog.ui
+  sources/interface/CloudDialog.ui \
+    sources/interface/OptionsDialog.ui
 
 # RtOsc
 INCLUDEPATH += $$PWD/libraries/rtosc/include

--- a/Frontieres.pro
+++ b/Frontieres.pro
@@ -10,8 +10,7 @@ DEFINES += __LINUX_ALSASEQ__
 DEFINES += __UNIX_JACK__
 
 INCLUDEPATH += $$PWD/libraries/QtFont3D
-SOURCES += libraries/QtFont3D/QtFont3D.cpp \
-    sources/interface/OptionsDialog.cpp
+SOURCES += libraries/QtFont3D/QtFont3D.cpp
 HEADERS += libraries/QtFont3D/QtFont3D.h \
     sources/interface/OptionsDialog.h
 
@@ -50,6 +49,7 @@ SOURCES += \
   sources/interface/StartDialog.cpp \
   sources/interface/AdsrDialog.cpp \
   sources/interface/CloudDialog.cpp \
+  sources/interface/OptionsDialog.cpp \
   sources/interface/Node.cpp \
   sources/dsp/Window.cpp \
   sources/model/Adsr.cpp \
@@ -79,6 +79,7 @@ HEADERS += \
   sources/interface/StartDialog.h \
   sources/interface/AdsrDialog.h \
   sources/interface/CloudDialog.h \
+  sources/interface/OptionsDialog.h \
   sources/interface/Node.h \
   sources/dsp/Window.h \
   sources/model/Adsr.h \
@@ -103,7 +104,7 @@ FORMS += \
   sources/interface/StartDialog.ui \
   sources/interface/AdsrDialog.ui \
   sources/interface/CloudDialog.ui \
-    sources/interface/OptionsDialog.ui
+  sources/interface/OptionsDialog.ui
 
 # RtOsc
 INCLUDEPATH += $$PWD/libraries/rtosc/include

--- a/sources/Frontieres.cpp
+++ b/sources/Frontieres.cpp
@@ -983,7 +983,6 @@ int main(int argc, char **argv)
 
     std::string oscUrl = osc.getUrl();
     std::cout << "OSC address: " << oscUrl << "\n";
-    GLwindow->setupOscUrl(QString::fromStdString(oscUrl));
 
     // let Qt handle the current thread from here
     exitCode = app.exec();

--- a/sources/interface/CloudDialog.cpp
+++ b/sources/interface/CloudDialog.cpp
@@ -45,17 +45,19 @@ void CloudDialog::linkCloud(Cloud *cloudLinked, CloudVis *cloudVisLinked)
         ui->doubleSpinBox_Volume->setValue(cloudLinked->getVolumeDb());
     if (cloudLinked->changedPitch())
         ui->doubleSpinBox_Pitch->setValue(12*log2(cloudLinked->getPitch()));
-    //if (cloudVisLinked->
-    ui->doubleSpinBox_X_Extent->setValue(cloudVisLinked->getXRandExtent());
-    ui->doubleSpinBox_Y_Extent->setValue(cloudVisLinked->getYRandExtent());
-    ui->doubleSpinBox_X->setValue(cloudVisLinked->getX());
-    ui->doubleSpinBox_Y->setValue(cloudVisLinked->getY());
-    if (cloudLinked->getMidiChannel())
+    if (cloudVisLinked->changedXRandExtent())
+        ui->doubleSpinBox_X_Extent->setValue(cloudVisLinked->getXRandExtent());
+    if (cloudVisLinked->changedYRandExtent())
+        ui->doubleSpinBox_Y_Extent->setValue(cloudVisLinked->getYRandExtent());
+    if (cloudVisLinked->changedGcX())
+        ui->doubleSpinBox_X->setValue(cloudVisLinked->getX());
+    if (cloudVisLinked->changedGcY())
+        ui->doubleSpinBox_Y->setValue(cloudVisLinked->getY());
+    if (cloudLinked->changedMidiChannel())
         ui->doubleSpinBox_Midi_Channel->setValue(cloudLinked->getMidiChannel());
     if (cloudLinked->changedMidiNote())
         ui->doubleSpinBox_Midi_Note->setValue(cloudLinked->getMidiNote());
     ui->label_Id_Value->setText(QString::number(cloudLinked->getId()));
-    //ui->label_Num_Value->setValue(cloudLinked->getNum());
     ui->checkBox_Active->setChecked(cloudLinked->getActiveState());
     ui->checkBox_Locked->setChecked(cloudLinked->getLockedState());
     if (cloudLinked->changedDirection())
@@ -72,7 +74,7 @@ void CloudDialog::linkCloud(Cloud *cloudLinked, CloudVis *cloudVisLinked)
         default :
             break;
         }
-    if (cloudLinked->getSpatialMode())
+    if (cloudLinked->changedSpatialMode())
         switch (cloudLinked->getSpatialMode()) {
         case UNITY:
             ui->radioButton_Balance_Unity->setChecked(true);
@@ -86,7 +88,7 @@ void CloudDialog::linkCloud(Cloud *cloudLinked, CloudVis *cloudVisLinked)
         default :
             break;
         }
-    if (cloudLinked->getWindowType())
+    if (cloudLinked->changedWindowType())
         switch (cloudLinked->getWindowType()) {
         case HANNING:
             ui->radioButton_Window_Hanning->setChecked(true);

--- a/sources/interface/CloudDialog.cpp
+++ b/sources/interface/CloudDialog.cpp
@@ -7,7 +7,6 @@ CloudDialog::CloudDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::CloudDialog)
 {
-    // std::cout << "cloud dialog construct" << std::endl;
     setModal(false);
     ui->setupUi(this);
 
@@ -18,7 +17,6 @@ CloudDialog::CloudDialog(QWidget *parent) :
 
 CloudDialog::~CloudDialog()
 {
-    // std::cout << "cloud dialog destruct" << std::endl;
     delete ui;
 }
 
@@ -33,71 +31,85 @@ void CloudDialog::linkCloud(Cloud *cloudLinked, CloudVis *cloudVisLinked)
     linking = true;
     cloudRef = cloudLinked;
     cloudVisRef = cloudVisLinked;
-    ui->doubleSpinBox_Duration->setValue(cloudLinked->getDurationMs());
-    ui->doubleSpinBox_Grains ->setValue(cloudLinked->getNumGrains());
-    ui->doubleSpinBox_LFO_Amp->setValue(cloudLinked->getPitchLFOAmount());
-    ui->doubleSpinBox_LFO_Freq->setValue(cloudLinked->getPitchLFOFreq());
-    ui->doubleSpinBox_Overlap->setValue(cloudLinked->getOverlap());
-    ui->doubleSpinBox_Volume->setValue(cloudLinked->getVolumeDb());
-    ui->doubleSpinBox_Pitch->setValue(12*log2(cloudLinked->getPitch()));
+    if (cloudLinked->changedDurationMs())
+        ui->doubleSpinBox_Duration->setValue(cloudLinked->getDurationMs());
+    if (cloudLinked->changedNumGrains())
+        ui->doubleSpinBox_Grains ->setValue(cloudLinked->getNumGrains());
+    if (cloudLinked->changedPitchLFOAmount())
+        ui->doubleSpinBox_LFO_Amp->setValue(cloudLinked->getPitchLFOAmount());
+    if (cloudLinked->changedPitchLFOFreq())
+        ui->doubleSpinBox_LFO_Freq->setValue(cloudLinked->getPitchLFOFreq());
+    if (cloudLinked->changedOverlap())
+        ui->doubleSpinBox_Overlap->setValue(cloudLinked->getOverlap());
+    if (cloudLinked->changedVolumeDb())
+        ui->doubleSpinBox_Volume->setValue(cloudLinked->getVolumeDb());
+    if (cloudLinked->changedPitch())
+        ui->doubleSpinBox_Pitch->setValue(12*log2(cloudLinked->getPitch()));
+    //if (cloudVisLinked->
     ui->doubleSpinBox_X_Extent->setValue(cloudVisLinked->getXRandExtent());
     ui->doubleSpinBox_Y_Extent->setValue(cloudVisLinked->getYRandExtent());
     ui->doubleSpinBox_X->setValue(cloudVisLinked->getX());
     ui->doubleSpinBox_Y->setValue(cloudVisLinked->getY());
-    ui->doubleSpinBox_Midi_Channel->setValue(cloudLinked->getMidiChannel());
-    ui->doubleSpinBox_Midi_Note->setValue(cloudLinked->getMidiNote());
+    if (cloudLinked->getMidiChannel())
+        ui->doubleSpinBox_Midi_Channel->setValue(cloudLinked->getMidiChannel());
+    if (cloudLinked->changedMidiNote())
+        ui->doubleSpinBox_Midi_Note->setValue(cloudLinked->getMidiNote());
     ui->label_Id_Value->setText(QString::number(cloudLinked->getId()));
     //ui->label_Num_Value->setValue(cloudLinked->getNum());
     ui->checkBox_Active->setChecked(cloudLinked->getActiveState());
     ui->checkBox_Locked->setChecked(cloudLinked->getLockedState());
-    switch (cloudLinked->getDirection()) {
-    case FORWARD:
-        ui->radioButton_Direction_Forward->setChecked(true);
-        break;
-    case BACKWARD:
-        ui->radioButton_Direction_Backward->setChecked(true);
-        break;
-    case RANDOM_DIR:
+    if (cloudLinked->changedDirection())
+        switch (cloudLinked->getDirection()) {
+        case FORWARD:
+            ui->radioButton_Direction_Forward->setChecked(true);
+            break;
+        case BACKWARD:
+            ui->radioButton_Direction_Backward->setChecked(true);
+            break;
+        case RANDOM_DIR:
             ui->radioButton_Direction_Random->setChecked(true);
-        break;
-    default :
-        break;
-    }
-    switch (cloudLinked->getSpatialMode()) {
-    case UNITY:
-        ui->radioButton_Balance_Unity->setChecked(true);
-        break;
-    case STEREO:
-        ui->radioButton_Balance_Stereo->setChecked(true);
-        break;
-    case AROUND:
+            break;
+        default :
+            break;
+        }
+    if (cloudLinked->getSpatialMode())
+        switch (cloudLinked->getSpatialMode()) {
+        case UNITY:
+            ui->radioButton_Balance_Unity->setChecked(true);
+            break;
+        case STEREO:
+            ui->radioButton_Balance_Stereo->setChecked(true);
+            break;
+        case AROUND:
             ui->radioButton_Balance_Around->setChecked(true);
-        break;
-    default :
-        break;
-    }
-    switch (cloudLinked->getWindowType()) {
-    case HANNING:
-        ui->radioButton_Window_Hanning->setChecked(true);
-        break;
-    case TRIANGLE:
-        ui->radioButton_Window_Triangle->setChecked(true);
-        break;
-    case EXPDEC:
-        ui->radioButton_Window_Expdec->setChecked(true);
-        break;
-    case REXPDEC:
-        ui->radioButton_Window_Rexpdec->setChecked(true);
-        break;
-    case SINC:
+            break;
+        default :
+            break;
+        }
+    if (cloudLinked->getWindowType())
+        switch (cloudLinked->getWindowType()) {
+        case HANNING:
+            ui->radioButton_Window_Hanning->setChecked(true);
+            break;
+        case TRIANGLE:
+            ui->radioButton_Window_Triangle->setChecked(true);
+            break;
+        case EXPDEC:
+            ui->radioButton_Window_Expdec->setChecked(true);
+            break;
+        case REXPDEC:
+            ui->radioButton_Window_Rexpdec->setChecked(true);
+            break;
+        case SINC:
             ui->radioButton_Window_Sinc->setChecked(true);
-        break;
-    case RANDOM_WIN:
+            break;
+        case RANDOM_WIN:
             ui->radioButton_Window_Random->setChecked(true);
-        break;
-    default :
-        break;
-    }
+            break;
+        default :
+            break;
+        }
+    cloudRef->changesDone(false);
     linking = false;
 }
 
@@ -252,7 +264,7 @@ void CloudDialog::on_doubleSpinBox_Pitch_valueChanged(double arg1)
 {
     ui->dial_Pitch->setValue(arg1 * 100);
     if (!linking)
-        cloudRef->setPitch(pow(2, (double) (arg1 / 12)));
+        cloudRef->setPitch(pow(2, (float) (arg1 / 12)));
 }
 
 void CloudDialog::on_verticalSlider_Volume_valueChanged(int value)

--- a/sources/interface/CloudDialog.ui
+++ b/sources/interface/CloudDialog.ui
@@ -161,6 +161,9 @@ border-bottom-left-radius: 9px;
          </item>
          <item>
           <widget class="QDoubleSpinBox" name="doubleSpinBox_Volume">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="decimals">
             <number>3</number>
            </property>
@@ -177,8 +180,14 @@ border-bottom-left-radius: 9px;
          </item>
          <item>
           <widget class="QPushButton" name="pushButton_Envelope">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
            <property name="text">
             <string>Envelope (e)</string>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -363,6 +372,9 @@ border-bottom-left-radius: 9px;
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
                  </property>
@@ -521,6 +533,9 @@ border-bottom-left-radius: 9px;
                  </property>
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
                  </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
@@ -690,6 +705,9 @@ border-bottom-left-radius: 9px;
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
                  </property>
@@ -854,6 +872,9 @@ border-bottom-left-radius: 9px;
                  </property>
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
                  </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
@@ -1025,6 +1046,9 @@ border-bottom-left-radius: 9px;
                  </property>
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
                  </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
@@ -1203,6 +1227,9 @@ border-bottom-left-radius: 9px;
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
                  </property>
@@ -1358,6 +1385,9 @@ border-bottom-left-radius: 9px;
                  </property>
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
                  </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
@@ -1524,6 +1554,9 @@ border-bottom-left-radius: 9px;
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
                  </property>
@@ -1689,6 +1722,9 @@ border-bottom-left-radius: 9px;
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
                  </property>
@@ -1853,6 +1889,9 @@ border-bottom-left-radius: 9px;
                  </property>
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
                  </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
@@ -2309,6 +2348,9 @@ border-bottom-left-radius: 9px;
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>
                  </property>
@@ -2409,6 +2451,9 @@ border-bottom-left-radius: 9px;
                  </property>
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::UpDownArrows</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
                  </property>
                  <property name="showGroupSeparator" stdset="0">
                   <bool>false</bool>

--- a/sources/interface/MyGLApplication.cpp
+++ b/sources/interface/MyGLApplication.cpp
@@ -22,6 +22,7 @@
 #include "MyGLApplication.h"
 #include "MyGLWindow.h"
 #include "CloudDialog.h"
+#include "OptionsDialog.h"
 #include "Frontieres.h"
 #include "I18n.h"
 #include "model/Sample.h"
@@ -227,6 +228,12 @@ void MyGLApplication::destroyAllCloudDialogs()
     while (P->cloudDialogs.size() > 0){
         destroyCloudDialog(P->cloudDialogs.begin()->first);
     }
+}
+
+void MyGLApplication::showOptionsDialog()
+{
+    OptionsDialog optionsDlg;
+    optionsDlg.exec();
 }
 
 void MyGLApplication::Impl::onIdle()

--- a/sources/interface/MyGLApplication.cpp
+++ b/sources/interface/MyGLApplication.cpp
@@ -187,7 +187,6 @@ void MyGLApplication::showCloudDialog(SceneCloud *selectedCloud)
         dlg->setWindowTitle(tr("Cloud parameters"));
         dlgslot = dlg;
     }
-
     dlg->show();
     selectedCloud->cloud.get()->changesDone(true);
     dlg->linkCloud(selectedCloud->cloud.get(), selectedCloud->view.get());

--- a/sources/interface/MyGLApplication.cpp
+++ b/sources/interface/MyGLApplication.cpp
@@ -96,6 +96,12 @@ bool MyGLApplication::loadSceneFile()
     if (nameSceneFile.empty())
         return false;
 
+    // delete cloudMaps if existing
+
+    while (P->cloudDialogs.size() > 0){
+        destroyCloudDialog(P->cloudDialogs.begin()->first);
+    }
+
     // load the scene and its samples
     Scene *scene = new Scene;
     QFile sceneFile(QString::fromStdString(nameSceneFile));

--- a/sources/interface/MyGLApplication.cpp
+++ b/sources/interface/MyGLApplication.cpp
@@ -96,11 +96,10 @@ bool MyGLApplication::loadSceneFile()
     if (nameSceneFile.empty())
         return false;
 
+
     // delete cloudMaps if existing
 
-    while (P->cloudDialogs.size() > 0){
-        destroyCloudDialog(P->cloudDialogs.begin()->first);
-    }
+    destroyAllCloudDialogs();
 
     // load the scene and its samples
     Scene *scene = new Scene;
@@ -221,6 +220,13 @@ void MyGLApplication::midiNoteOn(int midiChannelToPlay, int midiKeyToPlay, int m
 void MyGLApplication::midiNoteOff(int midiChannelToStop, int midiKeyToStop)
 {
     currentScene->midiNoteOff(midiChannelToStop, midiKeyToStop);
+}
+
+void MyGLApplication::destroyAllCloudDialogs()
+{
+    while (P->cloudDialogs.size() > 0){
+        destroyCloudDialog(P->cloudDialogs.begin()->first);
+    }
 }
 
 void MyGLApplication::Impl::onIdle()

--- a/sources/interface/MyGLApplication.cpp
+++ b/sources/interface/MyGLApplication.cpp
@@ -189,6 +189,7 @@ void MyGLApplication::showCloudDialog(SceneCloud *selectedCloud)
     }
 
     dlg->show();
+    selectedCloud->cloud.get()->changesDone(true);
     dlg->linkCloud(selectedCloud->cloud.get(), selectedCloud->view.get());
 }
 

--- a/sources/interface/MyGLApplication.h
+++ b/sources/interface/MyGLApplication.h
@@ -42,6 +42,7 @@ public:
     void destroyCloudDialog(unsigned selectedCloudId);
     void midiNoteOn (int midiChannelToPlay, int midiKeyToPlay, int midiVeloToPlay);
     void midiNoteOff (int midiChannelToStop, int midiKeyToStop);
+    void destroyAllCloudDialogs();
 
 private:
     struct Impl;

--- a/sources/interface/MyGLApplication.h
+++ b/sources/interface/MyGLApplication.h
@@ -43,6 +43,7 @@ public:
     void midiNoteOn (int midiChannelToPlay, int midiKeyToPlay, int midiVeloToPlay);
     void midiNoteOff (int midiChannelToStop, int midiKeyToStop);
     void destroyAllCloudDialogs();
+    void showOptionsDialog();
 
 private:
     struct Impl;

--- a/sources/interface/MyGLWindow.cpp
+++ b/sources/interface/MyGLWindow.cpp
@@ -64,6 +64,10 @@ void MyGLWindow::initialize()
             this, []() { theApplication->addSample(); });
     connect(P->ui.action_Load_clouds_defaults, &QAction::triggered,
             this, []() { theApplication->loadCloudDefaultFile(); });
+    connect(P->ui.action_Options, &QAction::triggered,
+            this, []() { theApplication->showOptionsDialog(); });
+    connect(P->ui.action_Control, &QAction::triggered,
+            this, []() { theApplication->showOptionsDialog(); });
 
 
     // initial window settings
@@ -78,34 +82,9 @@ void MyGLWindow::setMenuBarVisible(bool visible)
     P->ui.menubar->setVisible(visible);
 }
 
-void MyGLWindow::setupOscUrl(const QString &oscUrl)
-{
-    QMenu *menu = P->ui.menu_OSC;
-    menu->insertSeparator(menu->actions().first());
-    QAction *head = new QAction(oscUrl, menu);
-    menu->insertAction(menu->actions().first(), head);
-    head->setEnabled(false);
-}
-
 MyGLScreen *MyGLWindow::screen() const
 {
     return P->ui.screen;
-}
-
-void MyGLWindow::on_action_Start_controller_triggered()
-{
-    MyRtOsc &osc = MyRtOsc::instance();
-
-    // TODO make a configuration for this command
-    QString program = "open-stage-control";
-    QStringList arguments;
-    arguments << "-s" << ("0.0.0.0:" + QString::number(osc.getPort()));
-
-    if (!QProcess::startDetached(program, arguments))
-        QMessageBox::warning(
-            this, tr("Error"),
-            tr("Cannot lanch the program: %1").arg(program) + "\n" +
-            tr("Please ensure the software is installed and the path is correct."));
 }
 
 // the openGL screen

--- a/sources/interface/MyGLWindow.h
+++ b/sources/interface/MyGLWindow.h
@@ -36,11 +36,7 @@ public:
     ~MyGLWindow();
     void initialize();
     void setMenuBarVisible(bool visible);
-    void setupOscUrl(const QString &oscUrl);
     MyGLScreen *screen() const;
-
-public slots:
-    void on_action_Start_controller_triggered();
 
 private:
     struct Impl;

--- a/sources/interface/MyGLWindow.ui
+++ b/sources/interface/MyGLWindow.ui
@@ -57,12 +57,14 @@
      <string>&amp;Edit</string>
     </property>
     <addaction name="action_Add_sample"/>
+    <addaction name="separator"/>
+    <addaction name="action_Options"/>
    </widget>
    <widget class="QMenu" name="menu_OSC">
     <property name="title">
      <string>&amp;OSC</string>
     </property>
-    <addaction name="action_Start_controller"/>
+    <addaction name="action_Control"/>
    </widget>
    <addaction name="menu_File"/>
    <addaction name="menu_Edit"/>
@@ -102,6 +104,16 @@
   <action name="action_Start_controller">
    <property name="text">
     <string>&amp;Start controller</string>
+   </property>
+  </action>
+  <action name="action_Options">
+   <property name="text">
+    <string>&amp;Options</string>
+   </property>
+  </action>
+  <action name="action_Control">
+   <property name="text">
+    <string>&amp;Control</string>
    </property>
   </action>
  </widget>

--- a/sources/interface/OptionsDialog.cpp
+++ b/sources/interface/OptionsDialog.cpp
@@ -1,0 +1,58 @@
+#include "OptionsDialog.h"
+#include "ui_OptionsDialog.h"
+#include "MyRtOsc.h"
+
+
+OptionsDialog::OptionsDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::OptionsDialog)
+{
+    ui->setupUi(this);
+    MyRtOsc &osc = MyRtOsc::instance();
+    std::string oscUrl = osc.getUrl();
+    std::cout << "OSC address: " << oscUrl << "\n";
+    ui->label_OSCServerLauncher->setText(QString::fromStdString(oscUrl));
+}
+
+OptionsDialog::~OptionsDialog()
+{
+    delete ui;
+}
+
+void OptionsDialog::on_lineEdit_OSCPort_textChanged(const QString &arg1)
+{
+
+}
+
+void OptionsDialog::on_pushButton_OSCServerLauncher_clicked()
+{
+    MyRtOsc &osc = MyRtOsc::instance();
+
+    // TODO make a configuration for this command
+    QString program = "open-stage-control";
+    QStringList arguments;
+    arguments << "-s" << ("0.0.0.0:" + QString::number(osc.getPort()));
+
+    if (!QProcess::startDetached(program, arguments))
+        QMessageBox::warning(
+            this, tr("Error"),
+            tr("Cannot lanch the program: %1").arg(program) + "\n" +
+            tr("Please ensure the software is installed and the path is correct."));
+}
+
+void OptionsDialog::on_pushButton_clicked()
+{
+
+    MyRtOsc &osc = MyRtOsc::instance();
+    osc.close();
+//    osc.setMessageHandler(&oscCallback, nullptr);
+    if (!osc.open(ui->lineEdit_OSCPort->text().toStdString().c_str()) || !osc.start()) {
+        std::cerr << "Error: failed to start OSC!\n";
+        return;
+    }
+
+    std::string oscUrl = osc.getUrl();
+    std::cout << "OSC address: " << oscUrl << "\n";
+    ui->label_OSCServerLauncher->setText(QString::fromStdString(oscUrl));
+    //GLwindow->setupOscUrl(QString::fromStdString(oscUrl));
+}

--- a/sources/interface/OptionsDialog.h
+++ b/sources/interface/OptionsDialog.h
@@ -1,0 +1,34 @@
+#ifndef OPTIONSDIALOG_H
+#define OPTIONSDIALOG_H
+
+#include <QDialog>
+#include <QApplication>
+#include <QMessageBox>
+#include <QProcess>
+#include <stdio.h>
+#include <iostream>
+
+namespace Ui {
+class OptionsDialog;
+}
+
+class OptionsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit OptionsDialog(QWidget *parent = 0);
+    ~OptionsDialog();
+
+private slots:
+    void on_lineEdit_OSCPort_textChanged(const QString &arg1);
+
+    void on_pushButton_OSCServerLauncher_clicked();
+
+    void on_pushButton_clicked();
+
+private:
+    Ui::OptionsDialog *ui;
+};
+
+#endif // OPTIONSDIALOG_H

--- a/sources/interface/OptionsDialog.ui
+++ b/sources/interface/OptionsDialog.ui
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OptionsDialog</class>
+ <widget class="QDialog" name="OptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>OSC</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QFrame" name="frame_3">
+         <property name="frameShape">
+          <enum>QFrame::Box</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="leftMargin">
+           <number>4</number>
+          </property>
+          <property name="topMargin">
+           <number>4</number>
+          </property>
+          <property name="rightMargin">
+           <number>4</number>
+          </property>
+          <property name="bottomMargin">
+           <number>4</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_OSCServerLauncher">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_OSCServerLauncher">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>&amp;Start controller</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QFrame" name="frame_4">
+         <property name="frameShape">
+          <enum>QFrame::Box</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="leftMargin">
+           <number>4</number>
+          </property>
+          <property name="topMargin">
+           <number>4</number>
+          </property>
+          <property name="rightMargin">
+           <number>4</number>
+          </property>
+          <property name="bottomMargin">
+           <number>4</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="pushButton">
+            <property name="text">
+             <string>Restart OSC</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QFrame" name="frame">
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <layout class="QFormLayout" name="formLayout">
+             <property name="horizontalSpacing">
+              <number>0</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>0</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_OSCPort">
+               <property name="text">
+                <string>OSC Port : </string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="lineEdit_OSCPort">
+               <property name="inputMask">
+                <string>99999</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string/>
+      </attribute>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/sources/model/Cloud.cpp
+++ b/sources/model/Cloud.cpp
@@ -201,6 +201,7 @@ void Cloud::setWindowType(int winType)
             myGrains[i]->setWindow(windowType);
         }
     }
+    changed_windowType = true;
 }
 
 int Cloud::getWindowType()
@@ -208,17 +209,28 @@ int Cloud::getWindowType()
     return windowType;
 }
 
+bool Cloud::changedWindowType()
+{
+    return changed_windowType;
+}
 
 void Cloud::addGrain()
 {
     addFlag = true;
     myCloudVis->addGrain();
+    changed_numGrains = true;
 }
 
 void Cloud::removeGrain()
 {
     removeFlag = true;
     myCloudVis->removeGrain();
+    changed_numGrains = true;
+}
+
+bool Cloud::changedNumGrains()
+{
+    return changed_numGrains;changedDirection();
 }
 
 // return id for grain
@@ -248,11 +260,17 @@ void Cloud::setOverlap(float target)
 
     //  cout<<"overlap set" << overlap << endl;
     updateBangTime();
+    changed_overlap = true;
 }
 
 float Cloud::getOverlap()
 {
     return overlapNorm;
+}
+
+bool Cloud::changedOverlap()
+{
+    return changed_overlap;
 }
 
 // duration
@@ -268,6 +286,7 @@ void Cloud::setDurationMs(float theDur)
         // notify visualization
         if (myCloudVis)
             myCloudVis->setDuration(duration);
+        changed_duration = true;
     }
 }
 
@@ -288,11 +307,17 @@ void Cloud::setPitch(float targetPitch)
     pitch = targetPitch;
     for (int i = 0; i < myGrains.size(); i++)
         myGrains[i]->setPitch(targetPitch);
+    changed_pitch = true;
 }
 
 float Cloud::getPitch()
 {
     return pitch;
+}
+
+bool Cloud::changedPitch()
+{
+    return changed_pitch;
 }
 
 
@@ -317,11 +342,17 @@ void Cloud::setVolumeDb(float volDb)
 
     for (int i = 0; i < myGrains.size(); i++)
         myGrains[i]->setVolume(normedVol);
+    changed_volumeDB = true;
 }
 
 float Cloud::getVolumeDb()
 {
     return volumeDb;
+}
+
+bool Cloud::changedVolumeDb()
+{
+    return changed_volumeDB;
 }
 
 
@@ -355,6 +386,7 @@ void Cloud::setDirection(int dirMode)
     default:
         break;
     }
+    changed_myDirMode = true;
 }
 
 
@@ -364,10 +396,20 @@ int Cloud::getDirection()
     return myDirMode;
 }
 
+bool Cloud::changedDirection()
+{
+    return changed_myDirMode;
+}
+
 // return duration in ms
 float Cloud::getDurationMs()
 {
     return duration;
+}
+
+bool Cloud::changedDurationMs()
+{
+    return changed_duration;
 }
 
 
@@ -379,7 +421,10 @@ unsigned int Cloud::getNumGrains()
 
 void Cloud::setNumGrains(unsigned int newNumGrains)
 {
-    numGrains = newNumGrains;
+    while (numGrains < newNumGrains)
+        addGrain();
+    while (numGrains > newNumGrains)
+        removeGrain();
 }
 
 // update after a change of sample set
@@ -402,11 +447,14 @@ ParamEnv Cloud::getEnvelopeVolumeParam ()
 void Cloud::setMidiChannel(int newMidiChannel)
 {
     midiChannel = newMidiChannel;
+    changed_midiChannel = true;
 }
 
 void Cloud::setMidiNote(int newMidiNote)
 {
     midiNote = newMidiNote;
+    //if (!editingDialog)
+    changed_midiNote = true;
 }
 
 int Cloud::getMidiChannel()
@@ -417,6 +465,16 @@ int Cloud::getMidiChannel()
 int Cloud::getMidiNote()
 {
     return midiNote;
+}
+
+bool Cloud::changedMidiChannel()
+{
+    return changed_midiChannel;
+}
+
+bool Cloud::changedMidiNote()
+{
+    return changed_midiNote;
 }
 
 void Cloud::setLockedState(bool newLockedState)
@@ -441,6 +499,32 @@ bool Cloud::dialogLocked()
     msgBox.setDefaultButton(QMessageBox::No);
     locked = msgBox.exec() == QMessageBox::No;
     return locked;
+}
+
+void Cloud::changesDone(bool done)
+{
+    changed_duration = done;
+    changed_midiChannel = done;
+    changed_midiNote = done;
+    changed_numGrains = done;
+    changed_overlap = done;
+    changed_pitch = done;
+    changed_pitchLFOAmount = done;
+    changed_pitchLFOFreq = done;
+    changed_volumeDB = done;
+    changed_windowType = done;
+    changed_myDirMode = done;
+    changed_spatialMode = done;
+}
+
+bool Cloud::getEditingdialog()
+{
+    return editingDialog;
+}
+
+void Cloud::setEditingDialog(bool editing)
+{
+    editingDialog = editing;
 }
 
 // print information
@@ -630,6 +714,7 @@ void Cloud::nextBuffer(double *accumBuff, unsigned int numFrames)
 void Cloud::setPitchLFOFreq(float pfreq)
 {
     pitchLFOFreq = fabs(pfreq);
+    changed_pitchLFOFreq = true;
 }
 
 void Cloud::setPitchLFOAmount(float lfoamt)
@@ -638,6 +723,7 @@ void Cloud::setPitchLFOAmount(float lfoamt)
         lfoamt = 0.0f;
     }
     pitchLFOAmount = lfoamt;
+    changed_pitchLFOAmount = true;
 }
 
 float Cloud::getPitchLFOFreq()
@@ -645,9 +731,19 @@ float Cloud::getPitchLFOFreq()
     return pitchLFOFreq;
 }
 
+bool Cloud::changedPitchLFOFreq()
+{
+    return changed_pitchLFOFreq;
+}
+
 float Cloud::getPitchLFOAmount()
 {
     return pitchLFOAmount;
+}
+
+bool Cloud::changedPitchLFOAmount()
+{
+    return changed_pitchLFOAmount;
 }
 
 
@@ -662,6 +758,7 @@ void Cloud::setSpatialMode(int theMode, int channelNumber = -1)
     // eventually swap out for azimuth instead of single channel
     if (channelNumber >= 0)
         channelLocation = channelNumber;
+    changed_spatialMode = true;
 }
 
 int Cloud::getSpatialMode()
@@ -671,6 +768,11 @@ int Cloud::getSpatialMode()
 int Cloud::getSpatialChannel()
 {
     return channelLocation;
+}
+
+bool Cloud::changedSpatialMode()
+{
+    return changed_spatialMode;
 }
 
 // spatialization logic

--- a/sources/model/Cloud.cpp
+++ b/sources/model/Cloud.cpp
@@ -421,10 +421,12 @@ unsigned int Cloud::getNumGrains()
 
 void Cloud::setNumGrains(unsigned int newNumGrains)
 {
-    while (myGrains.size() < newNumGrains)
-        addGrain();
-    while (myGrains.size() > newNumGrains)
-        removeGrain();
+    if (newNumGrains < myGrains.size())
+        for (int i=1; i <= (myGrains.size() - newNumGrains); ++i)
+            removeGrain();
+    else
+        for (int i=1; i <= (newNumGrains - myGrains.size()); ++i)
+            addGrain();
 }
 
 // update after a change of sample set

--- a/sources/model/Cloud.cpp
+++ b/sources/model/Cloud.cpp
@@ -421,9 +421,9 @@ unsigned int Cloud::getNumGrains()
 
 void Cloud::setNumGrains(unsigned int newNumGrains)
 {
-    while (numGrains < newNumGrains)
+    while (myGrains.size() < newNumGrains)
         addGrain();
-    while (numGrains > newNumGrains)
+    while (myGrains.size() > newNumGrains)
         removeGrain();
 }
 

--- a/sources/model/Cloud.cpp
+++ b/sources/model/Cloud.cpp
@@ -519,16 +519,6 @@ void Cloud::changesDone(bool done)
     changed_spatialMode = done;
 }
 
-bool Cloud::getEditingdialog()
-{
-    return editingDialog;
-}
-
-void Cloud::setEditingDialog(bool editing)
-{
-    editingDialog = editing;
-}
-
 // print information
 void Cloud::describe(std::ostream &out)
 {

--- a/sources/model/Cloud.h
+++ b/sources/model/Cloud.h
@@ -88,43 +88,53 @@ public:
     // set duration for all grains
     void setDurationMs(float theDur);
     float getDurationMs();
+    bool changedDurationMs();
 
 
     // overlap
     void setOverlap(float targetOverlap);
     float getOverlap();
+    bool changedOverlap();
 
     // pitch
     void setPitch(float targetPitch);
     float getPitch();
+    bool changedPitch();
 
     // pitch lfo methods
     void setPitchLFOFreq(float pfreq);
     float getPitchLFOFreq();
+    bool changedPitchLFOFreq();
     void setPitchLFOAmount(float lfoamt);
     float getPitchLFOAmount();
+    bool changedPitchLFOAmount();
 
     // direction
     void setDirection(int dirMode);
     int getDirection();
+    bool changedDirection();
 
     // add/remove grain
     void addGrain();
     void removeGrain();
+    bool changedNumGrains();
 
     // set window type
     void setWindowType(int windowType);
     int getWindowType();
+    bool changedWindowType();
 
 
     // spatialization methods (see enum for theMode.  channel number is optional and has default arg);
     void setSpatialMode(int theMode, int channelNumber);
     int getSpatialMode();
     int getSpatialChannel();
+    bool changedSpatialMode();
 
     // volume
     void setVolumeDb(float theVolDB);
     float getVolumeDb();
+    bool changedVolumeDb();
 
 
     // get unique id of cloud
@@ -161,11 +171,18 @@ public:
     void setMidiNote(int newMidiNote);
     int getMidiChannel();
     int getMidiNote();
+    bool changedMidiChannel();
+    bool changedMidiNote();
 
     // lock flag
     void setLockedState(bool newLockedState);
     bool getLockedState();
     bool dialogLocked();
+
+    // changes done
+    void changesDone(bool done);
+    bool getEditingdialog();
+    void setEditingDialog(bool editing);
 
 protected:
     // update internal trigger point
@@ -196,10 +213,12 @@ private:
     // spatialization
     double *channelMults;
     int spatialMode;
+    bool changed_spatialMode = false;
     int channelLocation;
 
     // volume
     float volumeDb, normedVol;
+    bool changed_volumeDB = false;
     float *envelopeVolumeBuff;
     double *intermediateBuff;
     enum EnvelopeAction { TriggerEnvelope = 1, ReleaseEnvelope = 2 };
@@ -211,10 +230,18 @@ private:
 
     // number of grains in this cloud
     unsigned int numGrains;
+    bool changed_numGrains = false;
 
     // cloud params
     float overlap, overlapNorm, pitch, duration, pitchLFOFreq, pitchLFOAmount;
     int myDirMode, windowType;
+    bool changed_overlap = false;
+    bool changed_pitch = false;
+    bool changed_duration = false;
+    bool changed_pitchLFOFreq = false;
+    bool changed_pitchLFOAmount = false;
+    bool changed_myDirMode = false;
+    bool changed_windowType = false;
 
     // audio files
     VecSceneSample *theSamples;
@@ -225,9 +252,13 @@ private:
     // midi params
     int midiChannel = 0;
     int midiNote;
+    bool changed_midiChannel = false;
+    bool changed_midiNote = false;
 
     // lock switch
     bool locked = false;
+
+    bool editingDialog = false;
 };
 
 #endif

--- a/sources/model/Cloud.h
+++ b/sources/model/Cloud.h
@@ -181,8 +181,6 @@ public:
 
     // changes done
     void changesDone(bool done);
-    bool getEditingdialog();
-    void setEditingDialog(bool editing);
 
 protected:
     // update internal trigger point
@@ -257,8 +255,6 @@ private:
 
     // lock switch
     bool locked = false;
-
-    bool editingDialog = false;
 };
 
 #endif

--- a/sources/visual/CloudVis.cpp
+++ b/sources/visual/CloudVis.cpp
@@ -124,6 +124,14 @@ void CloudVis::registerCloud(Cloud *cloudToRegister)
     myCloud = cloudToRegister;
 }
 
+void CloudVis::changesDone(bool done)
+{
+    changed_gcX= done;
+    changed_gcY = done;
+    changed_xRandExtent = done;
+    changed_yRandExtent = done;
+}
+
 // return cloud x
 float CloudVis::getX()
 {
@@ -198,28 +206,43 @@ void CloudVis::getTriggerPos(unsigned int idx, double *playPos,
 void CloudVis::setFixedXRandExtent(float X)
 {
     xRandExtent = X;
+    changed_xRandExtent = true;
 }
 
 void CloudVis::setFixedYRandExtent(float Y)
 {
     yRandExtent = Y;
+    changed_yRandExtent = true;
 }
 void CloudVis::setFixedRandExtent(float X, float Y)
 {
     setFixedXRandExtent(X);
     setFixedYRandExtent(Y);
 }
+
+bool CloudVis::changedXRandExtent()
+{
+    return changed_xRandExtent;
+}
+
+bool CloudVis::changedYRandExtent()
+{
+    return changed_yRandExtent;
+}
+
 void CloudVis::setXRandExtent(float mouseX)
 {
     xRandExtent = fabs(mouseX - gcX);
     if (xRandExtent < 2.0f)
         xRandExtent = 0.0f;
+    changed_xRandExtent = true;
 }
 void CloudVis::setYRandExtent(float mouseY)
 {
     yRandExtent = fabs(mouseY - gcY);
     if (yRandExtent < 2.0f)
         yRandExtent = 0.0f;
+    changed_yRandExtent = true;
 }
 void CloudVis::setRandExtent(float mouseX, float mouseY)
 {
@@ -243,6 +266,16 @@ void CloudVis::setY(int newY)
 {
     updateCloudPosition(gcX, newY);
 }
+
+bool CloudVis::changedGcX()
+{
+    return changed_gcX;
+}
+
+bool CloudVis::changedGcY()
+{
+    return changed_gcY;
+}
 //
 void CloudVis::updateCloudPosition(float x, float y)
 {
@@ -255,6 +288,8 @@ void CloudVis::updateCloudPosition(float x, float y)
         float newGrainY = myGrainsV[i]->getY() + yDiff;
         myGrainsV[i]->moveTo(newGrainX, newGrainY);
     }
+    changed_gcX = true;
+    changed_gcY = true;
 }
 
 void CloudVis::updateGrainPosition(int idx, float x, float y)

--- a/sources/visual/CloudVis.h
+++ b/sources/visual/CloudVis.h
@@ -79,6 +79,8 @@ public:
     float getY();
     void setX(int newX);
     void setY(int newY);
+    bool changedGcX();
+    bool changedGcY();
 
     // randomness params for grain positions
     float getXRandExtent();
@@ -89,6 +91,8 @@ public:
     void setFixedXRandExtent(float X);
     void setFixedYRandExtent(float Y);
     void setFixedRandExtent(float X, float Y);
+    bool changedXRandExtent();
+    bool changedYRandExtent();
 
     // set the pulse duration (which determines the frequency of the pulse)
     void setDuration(float dur);
@@ -99,6 +103,9 @@ public:
     // register model
     void registerCloud(Cloud *cloudToRegister);
 
+    // changes done
+    void changesDone(bool done);
+
 protected:
 private:
     bool isOn, isSelected;
@@ -107,9 +114,13 @@ private:
     unsigned int screenWidth, screenHeight;
 
     float xRandExtent, yRandExtent;
+    bool changed_xRandExtent = false;
+    bool changed_yRandExtent = false;
 
     float freq;
     float gcX, gcY;
+    bool changed_gcX = false;
+    bool changed_gcY = false;
     float selRad, lambda, maxSelRad, minSelRad, targetRad;
     unsigned int numGrains;
     // registered visualization


### PR DESCRIPTION
il y avait un souci avec la zone numgrains, et ai mis des drapeux de mise à jour dans cloud sur les parametres concernes par les problemes dans clouddialog.
couplé au passage des doublespinbox en keyboardtracking = false, cela resout les autres soucis liés au passage à la gestion par timer, à part celui de la zone pitch à l'appui sur pageup ou pagedown en continu, qui doit venir d'ailleurs (sans doute une histoire d'arrondis de conversions entre multiplicateurs de frequences et demi tons...
j'ai aussi enlevé l'autofocus du bouton envelope qui empechait de pouvoir valider un changement dans un doublespinbox sous peine d'afficher la fenetre envelope