### PR TITLE
ajout fonction declencheurs sur les autres declencheurs 

### DIFF
--- a/sources/Version.h
+++ b/sources/Version.h
@@ -4,7 +4,7 @@
 // versioning following specifications on https://semver.org/
 
 int version_major = 0;
-int version_minor = 5;
+int version_minor = 6;
 int version_patch = 1;
 
 #endif // VERSION_H

--- a/sources/interface/AboutDialog.ui
+++ b/sources/interface/AboutDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>516</width>
+    <width>548</width>
     <height>257</height>
    </rect>
   </property>
@@ -21,6 +21,13 @@
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_Vers">
+     <property name="text">
+      <string>Version </string>
      </property>
     </widget>
    </item>

--- a/sources/interface/CloudDialog.cpp
+++ b/sources/interface/CloudDialog.cpp
@@ -333,7 +333,6 @@ void CloudDialog::linkCloud(Cloud *cloudLinked, CloudVis *cloudVisLinked)
         default :
             break;
         }
-
     cloudRef->changesDone(false);
     linking = false;
 }

--- a/sources/interface/MyGLWindow.cpp
+++ b/sources/interface/MyGLWindow.cpp
@@ -47,6 +47,7 @@
 
 extern string g_audioPath;
 extern CloudParams g_defaultCloudParams;
+extern int version_major, version_minor, version_patch;
 
 struct MyGLWindow::Impl {
     MyGLWindow *Q = nullptr;
@@ -160,6 +161,9 @@ void MyGLWindow::on_actionAbout_triggered()
     QDialog dlg(this);
     Ui::AboutDialog ui;
     ui.setupUi(&dlg);
+    ui.label_Vers->setText("Version " + QString::number(version_major, 10) + "."
+                                      + QString::number(version_minor, 10) + "."
+                                      + QString::number(version_patch, 10));
     dlg.exec();
 }
 

--- a/sources/interface/MyGLWindow.cpp
+++ b/sources/interface/MyGLWindow.cpp
@@ -879,6 +879,7 @@ void MyGLScreen::contextMenu_recordTrajectory()
     Trajectory *tr=nullptr;
 
     if (selectedTrigger) {
+        theApplication->destroyTriggerDialog(selectedTrigger->trigger->getId());
         tr=new Recorded(0, selectedTrigger->view->getOriginX(),selectedTrigger->view->getOriginY());
         selectedTrigger->trigger->setTrajectoryType(RECORDED);
         selectedTrigger->view->updateTriggerPosition(selectedTrigger->view->getOriginX(),selectedTrigger->view->getOriginY());
@@ -887,6 +888,7 @@ void MyGLScreen::contextMenu_recordTrajectory()
     }
     else
         if (selectedCloud) {
+            theApplication->destroyCloudDialog(selectedCloud->cloud->getId());
             tr=new Recorded(0, selectedCloud->view->getOriginX(),selectedCloud->view->getOriginY());
             selectedCloud->cloud->setTrajectoryType(RECORDED);
             selectedCloud->view->updateCloudPosition(selectedCloud->view->getOriginX(),selectedCloud->view->getOriginY());

--- a/sources/interface/TriggerDialog.cpp
+++ b/sources/interface/TriggerDialog.cpp
@@ -128,12 +128,12 @@ void TriggerDialog::linkTrigger(Trigger *triggerLinked, TriggerVis *triggerVisLi
         default :
             break;
         }
+    if (triggerLinked->changedPriority())
+        ui->spinBox_Priority->setValue(triggerLinked->getPriority());
     //cout << "forme trigger, link" << endl;
     if (triggerLinked->changedTrajectoryType())
-        cout << "forme trigger, traj changee" << endl;
         switch (triggerLinked->getTrajectoryType()) {
         case STATIC:
-            cout << "static" << endl;
             ui->radioButton_Trajectory_Static->setChecked(true);
             ui->doubleSpinBox_Speed->setDisabled(true);
             ui->doubleSpinBox_Radius->setDisabled(true);
@@ -152,7 +152,6 @@ void TriggerDialog::linkTrigger(Trigger *triggerLinked, TriggerVis *triggerVisLi
             break;
         case BOUNCING:
         {
-            cout << "bouncing" << endl;
             ui->radioButton_Trajectory_Bouncing->setChecked(true);
             ui->doubleSpinBox_Speed->setDisabled(false);
             ui->doubleSpinBox_Radius->setDisabled(false);
@@ -590,4 +589,10 @@ void TriggerDialog::on_radioButton_Out_Commute_toggled(bool checked)
 void TriggerDialog::on_checkBox_Restart_toggled(bool checked)
 {
     triggerRef->setActiveRestartTrajectory(checked);
+}
+
+void TriggerDialog::on_spinBox_Priority_valueChanged(int arg1)
+{
+    if (!linking)
+        triggerRef->setPriority(arg1);
 }

--- a/sources/interface/TriggerDialog.h
+++ b/sources/interface/TriggerDialog.h
@@ -106,6 +106,8 @@ private slots:
     
     void on_checkBox_Restart_toggled(bool checked);
 
+    void on_spinBox_Priority_valueChanged(int arg1);
+
 private:
     Ui::TriggerDialog *ui;
     bool linking = false;

--- a/sources/interface/TriggerDialog.ui
+++ b/sources/interface/TriggerDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>634</width>
-    <height>307</height>
+    <height>349</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -2638,19 +2638,16 @@
            </property>
            <layout class="QFormLayout" name="formLayout">
             <property name="horizontalSpacing">
-             <number>0</number>
+             <number>3</number>
             </property>
             <property name="verticalSpacing">
-             <number>0</number>
-            </property>
-            <property name="leftMargin">
-             <number>6</number>
+             <number>3</number>
             </property>
             <property name="topMargin">
-             <number>4</number>
+             <number>6</number>
             </property>
             <property name="rightMargin">
-             <number>0</number>
+             <number>3</number>
             </property>
             <property name="bottomMargin">
              <number>0</number>
@@ -2668,14 +2665,7 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="label_Id_Value">
-              <property name="text">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
+            <item row="2" column="0">
              <widget class="QCheckBox" name="checkBox_Active">
               <property name="text">
                <string>Active</string>
@@ -2683,16 +2673,39 @@
              </widget>
             </item>
             <item row="3" column="0">
+             <widget class="QCheckBox" name="checkBox_Restart">
+              <property name="text">
+               <string>Restart</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
              <widget class="QCheckBox" name="checkBox_Locked">
               <property name="text">
                <string>Locked</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QCheckBox" name="checkBox_Restart">
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_Priority">
+              <property name="frameShape">
+               <enum>QFrame::Panel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
               <property name="text">
-               <string>Restart</string>
+               <string>Priority : </string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QSpinBox" name="spinBox_Priority"/>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="label_Id_Value">
+              <property name="text">
+               <string/>
               </property>
              </widget>
             </item>
@@ -2749,7 +2762,7 @@
             <item>
              <widget class="QRadioButton" name="radioButton_Trajectory_Static">
               <property name="text">
-               <string>&amp;Static </string>
+               <string>S&amp;tatic </string>
               </property>
               <property name="checked">
                <bool>false</bool>

--- a/sources/model/Scene.cpp
+++ b/sources/model/Scene.cpp
@@ -43,10 +43,10 @@
 // TODO arrange this later
 #include "visual/CloudVis.h"
 #include "visual/TriggerVis.h"
-
 #include "Version.h"
 
 extern CloudParams g_defaultCloudParams;
+extern int version_major, version_minor, version_patch;
 
 //-----------------------------------------------------------------------------
 // Destructor

--- a/sources/model/Scene.cpp
+++ b/sources/model/Scene.cpp
@@ -535,6 +535,7 @@ bool Scene::load(QFile &sceneFile)
         int triggerActiveRestartTrajectory = objTrigger["active-restart-trajectory"].toBool();
         int triggerIn = objTrigger["in"].toInt();
         int triggerOut = objTrigger["out"].toInt();
+        int triggerPriority = objTrigger["priority"].toInt();
         double triggerX = objTrigger["x"].toDouble();
         double triggerY = objTrigger["y"].toDouble();
         int triggerZoneExtent = objTrigger["zone-extent"].toInt();
@@ -613,7 +614,8 @@ bool Scene::load(QFile &sceneFile)
         }
 
         cout << "trigger " << m_triggers.size() << " :" << "\n";
-        cout << "id " << triggerId << " :" << "\n";
+        cout << "id : " << triggerId << "\n";
+        cout << "priority " << triggerPriority << "\n";
         cout << "active = " << triggerActiveState << "\n";
         cout << "active restart trajectory = " << triggerActiveRestartTrajectory << "\n";
         cout << "in = " << triggerIn << "\n";
@@ -633,6 +635,7 @@ bool Scene::load(QFile &sceneFile)
         triggerVisToLoad->registerTrigger(triggerToLoad);
         triggerToLoad->setId(triggerId);
         triggerToLoad->setName(triggerName);
+        triggerToLoad->setPriority(triggerPriority);
         triggerToLoad->setActiveState(triggerActiveState);
         triggerToLoad->setActiveRestartTrajectory(triggerActiveRestartTrajectory);
         triggerToLoad->setIn(triggerIn);
@@ -1003,6 +1006,7 @@ bool Scene::save(QFile &sceneFile)
         QJsonObject objTrigger;
         objTrigger["id"] = (int)triggerToSave->getId();
         objTrigger["name"] = triggerToSave->getName();
+        objTrigger["priority"] = triggerToSave->getPriority();
         objTrigger["active-state"] = triggerToSave->getActiveState();
         objTrigger["active-restart-trajectory"] = triggerToSave->getActiveRestartTrajectory();
         objTrigger["in"] = triggerToSave->getIn();

--- a/sources/model/Trigger.h
+++ b/sources/model/Trigger.h
@@ -91,6 +91,14 @@ public:
     void computeCloudsIn ();
     void computeCloudsOut ();
 
+    void computeTriggersIn ();
+    void computeTriggersOut ();
+
+    void setPriority (int l_priority);
+    int getPriority ();
+    bool changedPriority();
+    bool isInListTriggersIn(int l_triggerId);
+
 private:
 
     unsigned int myId;  // unique id
@@ -120,6 +128,13 @@ private:
 
     // List of Clouds In
     QList<int> listCloudsIn;
+
+    // List of Triggers In
+    QList<int> listTriggersIn;
+
+    // Priority for trigger action on other triggers
+    int priority = 0;
+    bool changed_Priority = false;
 
 };
 

--- a/sources/visual/CloudVis.cpp
+++ b/sources/visual/CloudVis.cpp
@@ -542,7 +542,6 @@ void CloudVis::draw()
     if (isMidiVis & !isPlayed) {
         return;
     }
-
     double t_sec = 0;
     double dt = 0;
 

--- a/sources/visual/Trajectory.cpp
+++ b/sources/visual/Trajectory.cpp
@@ -131,7 +131,6 @@ void Trajectory::setTrajectoryStartTime()
 {
     trajectoryStartTime = GTime::instance().sec;
 }
-
 void Trajectory::setLastComputedPosition(int l_lcp)
 {
     lastComputedPosition = l_lcp;

--- a/sources/visual/Trajectory.h
+++ b/sources/visual/Trajectory.h
@@ -65,7 +65,7 @@ private:
     double stretch;
     double radiusInt;
     double expansion;
-    double trajectoryStartTime;
+    double trajectoryStartTime = 0;
     int lastComputedPosition = 0;
     double delayCumul = 0;
 };

--- a/sources/visual/TriggerVis.cpp
+++ b/sources/visual/TriggerVis.cpp
@@ -149,6 +149,8 @@ void TriggerVis::draw()
         updateTriggerPosition(pos.x,pos.y);
         myTrigger->computeCloudsIn();
         myTrigger->computeCloudsOut();
+        myTrigger->computeTriggersIn();
+        myTrigger->computeTriggersOut();
     }
 
     glPushMatrix();


### PR DESCRIPTION
passage en version 0.6.1 pour nouvelle fonction
- nouvelle fonction : les declencheurs peuvent maintenant agir aussi sur d'autres déclencheurs

pour cela une nouvelle propiete Priorité a été ajoutée au déclancheur. 
si un declencheur a une priorité inferieure a un autre, il n'aura aucune action sur lui
si les priorités sont identiques, le premier à agir sur l'autre empechera l'autre d'agir sur lui (afin d'eviter des boucles sans fin)
si un declencheur a une priorité superieure, il agira sur l'autre

l'action d'un declencheur sur un autre se fait comme pour un nuage, il faut que la zone d'extension du declencheur entre en intersection avec la coeur d'un autre.

- reparation bug sur enregistrement trajectoire si clouddialog ou triggerdialog existe.

ce bug plantait Frontieres lorsqu'on essayait d'enregistrer une trajectoire sur un nuage ou un declencheur si le dialog existait.
je n'ai pas reussi a comprendre reellement pourquoi, mais ai resolu le probleme en detruisant un eventuel dialogue si on demande l'enregistrement d'une trajectoire.

