### PR TITLE
Gestion des entrées audio

### DIFF
--- a/sources/MyRtAudio.h
+++ b/sources/MyRtAudio.h
@@ -48,7 +48,8 @@ public:
     virtual ~AbstractAudio() {}
 
     // set the audio callback and start the audio stream
-    typedef void (*AudioCallback)(BUFFERPREC *out, unsigned int numFrames, void *userData);
+    typedef void (*AudioCallback)(
+        const BUFFERPREC *in, BUFFERPREC *out, unsigned int numFrames, void *userData);
     virtual bool openStream(AudioCallback callback, void *userData) = 0;
 
     // connect outputs
@@ -59,6 +60,9 @@ public:
 
     // report the current buffer size
     virtual unsigned int getBufferSize() = 0;
+
+    // get the obtained channel count
+    virtual unsigned int getObtainedInputChannels() = 0;
 
     // get the obtained channel count
     virtual unsigned int getObtainedOutputChannels() = 0;
@@ -86,7 +90,7 @@ class MyRtAudio : public AbstractAudio {
 
 public:
     // constructor - args =
-    explicit MyRtAudio(unsigned int numOuts);
+    MyRtAudio(unsigned int numIns, unsigned int numOuts);
 
     // set the audio callback and start the audio stream
     bool openStream(AudioCallback callback, void *userData) override;
@@ -94,6 +98,7 @@ public:
 
     unsigned int getSampleRate() override;
     unsigned int getBufferSize() override;
+    unsigned int getObtainedInputChannels() override;
     unsigned int getObtainedOutputChannels() override;
     bool startStream() override;
     bool stopStream() override;
@@ -106,6 +111,7 @@ private:
     // rtaudio pointer
     std::unique_ptr<RtAudio> audio;
     std::unique_ptr<RtMidiIn> midiIn;
+    unsigned int numInputs;
     unsigned int numOutputs;
 
     // buffer size, sample rate, rt audio format
@@ -134,7 +140,7 @@ class MyRtJack : public AbstractAudio {
 
 public:
     // constructor - args =
-    explicit MyRtJack(unsigned int numOuts);
+    MyRtJack(unsigned int numIns, unsigned int numOuts);
 
     // set the audio callback and start the audio stream
     bool openStream(AudioCallback callback, void *userData) override;
@@ -142,6 +148,7 @@ public:
 
     unsigned int getSampleRate() override;
     unsigned int getBufferSize() override;
+    unsigned int getObtainedInputChannels() override;
     unsigned int getObtainedOutputChannels() override;
     bool startStream() override;
     bool stopStream() override;
@@ -156,9 +163,12 @@ private:
     ReceiveMidi receiveMidiIn = nullptr;
     void *receiveMidiInUserData = nullptr;
 
+    unsigned numInputs = 0;
     unsigned numOutputs = 0;
+    std::unique_ptr<float[]> inputBuffer;
     std::unique_ptr<float[]> outputBuffer;
 
+    std::vector<jack_port_t *> inputs;
     std::vector<jack_port_t *> outputs;
     jack_port_t *midiIn = nullptr;
 

--- a/sources/interface/CloudDialog.cpp
+++ b/sources/interface/CloudDialog.cpp
@@ -107,8 +107,8 @@ CloudDialog::CloudDialog(QWidget *parent) :
 
     ui->doubleSpinBox_Output_First->setMinimum(0);
     ui->doubleSpinBox_Output_Last->setMinimum(0);
-    ui->doubleSpinBox_Output_First->setMaximum(theChannelCount - 1);
-    ui->doubleSpinBox_Output_Last->setMaximum(theChannelCount - 1);
+    ui->doubleSpinBox_Output_First->setMaximum(theOutChannelCount - 1);
+    ui->doubleSpinBox_Output_Last->setMaximum(theOutChannelCount - 1);
 
     QTimer *tmAutoUpdate = new QTimer(this);
     connect(tmAutoUpdate, &QTimer::timeout, this, &CloudDialog::autoUpdate);

--- a/sources/model/Cloud.cpp
+++ b/sources/model/Cloud.cpp
@@ -57,7 +57,7 @@ CloudMidi::CloudMidi(VecSceneSample *sampleSet, float theNumGrains, float theDur
 {
     envelopeVolume = new Env;
     envelopeVolumeBuff = new float[g_buffSize];
-    intermediateBuff = new double[g_buffSize * theChannelCount];
+    intermediateBuff = new double[g_buffSize * theOutChannelCount];
     envelopeAction.store(0);
     isActive = false;
     addFlag = false;
@@ -98,7 +98,7 @@ Cloud::~Cloud()
 Cloud::Cloud(VecSceneSample *sampleSet, float theNumGrains)
 {
     //cout << "creation cloud" << endl;
-    unsigned channelCount = theChannelCount;
+    unsigned channelCount = theOutChannelCount;
 
     // cloud id
     myId = ++cloudId;
@@ -893,7 +893,7 @@ Env Cloud::getEnvelopeVolume()
 // compute audio
 void Cloud::nextBuffer(BUFFERPREC *accumBuff, unsigned int numFrames)
 {
-    unsigned channelCount = theChannelCount;
+    unsigned channelCount = theOutChannelCount;
 
     // debug std::cout<<"entree nextbuffer cloud"<<std::endl;
     int l_envelopeAction = this->envelopeAction.exchange(0);
@@ -1228,7 +1228,7 @@ int Cloud::getOutputLast()
 // spatialization logic
 void Cloud::updateSpatialization()
 {
-    unsigned channelCount = theChannelCount;
+    unsigned channelCount = theOutChannelCount;
 
     // currently assumes orientation L: 0,2,4,...  R: 1,3,5, etc (interleaved)
     switch (spatialMode) {

--- a/sources/model/Grain.cpp
+++ b/sources/model/Grain.cpp
@@ -55,7 +55,7 @@ Grain::~Grain()
 
 Grain::Grain(VecSceneSample *sampleSet, float durationMs, float thePitch)
 {
-    unsigned channelCount = theChannelCount;
+    unsigned channelCount = theOutChannelCount;
 
     // store pointer to external vector of sample files
     theSamples = sampleSet;
@@ -176,7 +176,7 @@ bool Grain::isPlaying()
 //-----------------------------------------------------------------------------
 void Grain::setChannelMultipliers(double *multipliers)
 {
-    unsigned channelCount = theChannelCount;
+    unsigned channelCount = theOutChannelCount;
     for (int i = 0; i < channelCount; i++) {
         queuedChanMults[i] = multipliers[i];
     }
@@ -238,7 +238,7 @@ float Grain::getPitch()
 //-----------------------------------------------------------------------------
 void Grain::updateParams()
 {
-    unsigned channelCount = theChannelCount;
+    unsigned channelCount = theOutChannelCount;
 
     // update parameter set
 
@@ -331,7 +331,7 @@ void Grain::setDirection(float thedir)
 void Grain::nextBuffer(double *accumBuff, unsigned int numFrames,
                             unsigned int bufferOffset, int name)
 {
-    unsigned channelCount = theChannelCount;
+    unsigned channelCount = theOutChannelCount;
 
     // fill stereo accumulation buffer.  note, buffer output must be interlaced
     // ch1,ch2,ch1,ch2, etc... and playPositions are in frames, NOT SAMPLES.

--- a/sources/model/Scene.cpp
+++ b/sources/model/Scene.cpp
@@ -1746,7 +1746,7 @@ void Scene::initDefaultCloudParams()
     g_defaultCloudParams.windowType = HANNING;
     g_defaultCloudParams.spatialMode = UNITY;
     g_defaultCloudParams.outputFirst = 0;
-    g_defaultCloudParams.outputLast = theChannelCount - 1;
+    g_defaultCloudParams.outputLast = theOutChannelCount - 1;
     g_defaultCloudParams.channelLocation = -1;
     g_defaultCloudParams.numGrains = 8;
     g_defaultCloudParams.activateState = true;

--- a/sources/theglobals.h
+++ b/sources/theglobals.h
@@ -37,8 +37,10 @@
 
 // create BUFFERPREC datatype
 typedef float BUFFERPREC;
+// number of input channels
+extern int theInChannelCount;
 // number of output channels
-extern int theChannelCount;
+extern int theOutChannelCount;
 
 // window length
 #define WINDOW_LEN 2048


### PR DESCRIPTION
#94, @olof29

J'ai implémenté rapidement une gestion de l'entrée audio.
Il y a un fanion `-i N` qui indique le nombre de canaux d'entrées souhaités.

Le buffer des entrées est récupéré par `audioCallback` en échantillons entrelacés.

Tu peux essayer cette implémentation.
Si cela convient, je la fusionne plus tard.